### PR TITLE
Migrar páginas de guias para CADASTUR

### DIFF
--- a/guia.html
+++ b/guia.html
@@ -10,9 +10,7 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
     <link rel="stylesheet" href="styles.css">
 </head>
-<!-- Removed guide-page class to prevent scripts.js from initializing the profile via initGuideProfilePage().
-     The guide profile is now rendered by guide_profile.js using CADASTUR data. -->
-<body>
+<body class="guide-profile-page">
     <header>
         <div class="nav-container">
             <a href="index.html" class="logo"><i class="fas fa-mountain"></i>Trekko Brasil</a>
@@ -43,10 +41,9 @@
         </div>
     </header>
     <main>
-        <nav id="breadcrumb" class="breadcrumb"></nav>
-        <section class="guide-detail-section">
+        <section class="guide-detail-wrapper">
             <div class="container">
-                <div id="guideProfile" class="guide-detail"></div>
+                <div id="guide-detail"></div>
             </div>
         </section>
     </main>
@@ -83,16 +80,16 @@
         </div>
         <div class="footer-bottom">© 2025 Trekko Brasil. Todos os direitos reservados.</div>
     </footer>
-    <script src="data/trails.js"></script>
-    <script src="data/expeditions.js"></script>
-    <!-- CADASTUR dataset for guides -->
-    <script src="data/cadastur.js"></script>
-    <!-- Legacy guides dataset (still used for some features) -->
-    <script src="data/guides.js"></script>
-    <script src="data/blog.js"></script>
     <script src="auth.js"></script>
     <script src="scripts.js"></script>
-    <!-- Load dedicated guide profile script after the global scripts -->
+
+    <!-- Fonte oficial (CSV preferido + fallback JS) -->
+    <script>
+      window.__USE_CSV__ = true; // igual à listagem
+    </script>
+    <script src="data/cadastur.js"></script>
+
+    <!-- Script dedicado ao perfil (usa somente CADASTUR) -->
     <script src="guide_profile.js"></script>
 </body>
 </html>

--- a/guias.html
+++ b/guias.html
@@ -70,55 +70,47 @@
         <!-- Filters -->
         <div class="guide-filters" style="display:flex;flex-wrap:wrap;gap:1rem;margin-bottom:1rem;">
             <div class="filter-field" style="flex:1 1 220px;">
-                <label for="guideSearch">Nome ou Nº Cadastur</label>
-                <input type="text" id="guideSearch" placeholder="Pesquisar..." />
+                <label for="searchInput">Nome ou Nº Cadastur</label>
+                <input type="text" id="searchInput" placeholder="Pesquisar..." />
             </div>
             <div class="filter-field" style="flex:1 1 160px;">
-                <label for="guideStateFilter">Estado</label>
-                <select id="guideStateFilter">
-                    <option value="">Todos</option>
+                <label for="filterUF">Estado</label>
+                <select id="filterUF">
+                    <option value="">Todos os Estados</option>
                     <!-- options populated via JS -->
                 </select>
             </div>
             <div class="filter-field" style="flex:1 1 160px;">
-                <label for="guideCityFilter">Cidade</label>
-                <select id="guideCityFilter" disabled>
-                    <option value="">Todas</option>
+                <label for="filterCity">Cidade</label>
+                <select id="filterCity">
+                    <option value="">Todas as Cidades</option>
                 </select>
             </div>
             <div class="filter-field" style="flex:1 1 160px;">
-                <label for="guideSort">Ordenar por</label>
-                <select id="guideSort">
-                    <option value="name-asc">Nome (A–Z)</option>
-                    <option value="name-desc">Nome (Z–A)</option>
-                    <option value="city-asc">Cidade (A–Z)</option>
-                    <option value="city-desc">Cidade (Z–A)</option>
+                <label for="sortSelect">Ordenar por</label>
+                <select id="sortSelect">
+                    <option value="name_asc">Nome (A–Z)</option>
+                    <option value="name_desc">Nome (Z–A)</option>
+                    <option value="city_asc">Cidade (A–Z)</option>
+                    <option value="city_desc">Cidade (Z–A)</option>
                 </select>
             </div>
             <div style="display:flex;align-items:flex-end;">
-                <button id="clearGuideFilters" class="btn-clear" style="margin-top:auto;">Limpar</button>
+                <button id="clearFilters" class="btn-clear" style="margin-top:auto;">Limpar</button>
             </div>
         </div>
 
         <!-- Counters -->
-        <div id="guideCounters" style="margin-bottom:1rem;font-size:0.95rem;color:var(--color-muted);">
+        <div id="guidesCounters" style="margin-bottom:1rem;font-size:0.95rem;color:var(--color-muted);">
             <!-- dynamic counters inserted here -->
         </div>
 
         <!-- Guide Cards Grid -->
-        <div id="guideList" class="guide-grid" style="display:grid;gap:1.5rem;"></div>
+        <div id="guidesGrid" class="guide-grid" style="display:grid;gap:1.5rem;"></div>
 
         <!-- Pagination -->
         <div id="pagination" class="pagination" style="margin-top:2rem;display:flex;justify-content:center;gap:0.5rem;"></div>
     </main>
-
-    <!-- Contact Modal -->
-    <div id="guideContactModal" class="modal">
-        <div class="modal-content" style="max-width:400px;">
-            <button id="guideContactClose" class="modal-close">&times;</button>
-            <div id="guideContactContent"></div>
-        </div>
-    </div>
 
     <!-- Footer -->
     <footer>
@@ -156,12 +148,18 @@
     </footer>
 
     <!-- Load scripts -->
+    <!-- Auth + utilidades globais -->
     <script src="auth.js"></script>
-    <!-- Main script (nav, search, modals) -->
     <script src="scripts.js"></script>
-    <!-- Data for CADASTUR guides -->
+
+    <!-- Fonte oficial de dados -->
+    <!-- Preferência: CSV; fallback: JS embutido quando rodar via file:// -->
+    <script>
+      window.__USE_CSV__ = true; // mude para false só se estiver testando via file:// sem servidor
+    </script>
     <script src="data/cadastur.js"></script>
-    <!-- Guides list script -->
+
+    <!-- Lógica da listagem de guias (somente CADASTUR) -->
     <script src="guides_list.js"></script>
 </body>
 </html>

--- a/guide_profile.js
+++ b/guide_profile.js
@@ -1,165 +1,140 @@
-/*
- * Guide profile page script for Trekko Brasil
- *
- * This script is responsible for populating the guia.html page with
- * information about a single guide based on the CADASTUR dataset. It
- * parses the query parameters for a slug or cadastur number, searches
- * through the window.cadasturData array for a matching entry, and then
- * builds the profile details including photo, name, Cadastur number,
- * location, languages, bio and contact information. If no guide is
- * found, it displays a fallback message. This script operates
- * independently of the larger scripts.js logic to ensure the profile
- * page always renders correctly even when the main scripts are
- * modified.
- */
+/* guide_profile.js – Perfil do Guia via CADASTUR */
 
-// Use the load event instead of DOMContentLoaded because guia.html loads this
-// script at the end of the document. If DOMContentLoaded has already fired
-// before this script is parsed, a listener on DOMContentLoaded would never
-// trigger. The load event guarantees the code runs once resources are
-// finished loading.
-window.addEventListener('load', () => {
-  // Only run on the guia profile page (avoid interference on other pages)
-  const container = document.getElementById('guideProfile');
+(function () {
+  const container = document.getElementById('guide-detail');
   if (!container) return;
-  // Clear any existing content before populating the profile
-  container.innerHTML = '';
 
-  // Helper: slugify a string (remove accents, special characters, lower case)
-  function slugify(str) {
-    return String(str || '')
-      .normalize('NFD')
-      .replace(/[\u0300-\u036f]/g, '')
+  const slugify = (s) =>
+    (s || '')
+      .normalize('NFD').replace(/[\u0300-\u036f]/g, '')
       .toLowerCase()
       .replace(/[^a-z0-9]+/g, '-')
-      .replace(/^-+|-+$/g, '');
-  }
+      .replace(/(^-|-$)/g, '');
 
-  // Normalise a raw CADASTUR entry into a guide object with standard fields
-  function normaliseCadastur(entry) {
-    const guide = {};
-    guide.name = entry.nome || entry.nome_completo || entry.name || '';
-    guide.cadastur = entry.numero_cadastur || entry.numero || entry.numero_cad || entry['nº cadastur'] || entry['número cadastur'] || '';
-    guide.uf = entry.uf || entry.estado || entry.state || '';
-    guide.city = entry.municipio || entry.município || entry.cidade || entry.city || '';
-    guide.languages = [];
-    if (entry.idiomas) {
-      if (Array.isArray(entry.idiomas)) {
-        guide.languages = entry.idiomas;
-      } else {
-        guide.languages = String(entry.idiomas)
-          .split(/\||,|;/)
-          .map(s => s.trim())
-          .filter(Boolean);
+  const parseContacts = (s) => {
+    if (!s) return {};
+    let wpp = (/whats(app)?:\s*([^|]+)/i.exec(s) || [])[2];
+    let ig  = (/insta(gram)?:\s*([^|]+)/i.exec(s) || [])[2];
+    let em  = (/mail|e-?mail:\s*([^|]+)/i.exec(s) || [])[2];
+    return {
+      whatsapp: wpp ? wpp.trim() : '',
+      instagram: ig ? ig.trim().replace(/^@/, '') : '',
+      email: em ? em.trim() : ''
+    };
+  };
+
+  const norm = (row) => {
+    const get = (...keys) => {
+      for (const k of keys) {
+        const v = row[k]; if (v != null && String(v).trim() !== '') return String(v).trim();
       }
-    }
-    guide.contacts = [];
-    if (entry.contatos) {
-      const parts = String(entry.contatos).split(/\||,/);
-      parts.forEach(part => {
-        const [type, value] = part.split(/[:：]/);
-        if (value) {
-          guide.contacts.push({ type: type.trim(), value: value.trim() });
+      return '';
+    };
+    const name = get('nome','nome_completo','name');
+    const cad  = get('numero_cadastur','cadastur','n_cadastur','número_cadastur');
+    const uf   = get('uf','estado','estado_uf');
+    const city = get('municipio','cidade','city');
+    const bio  = get('bio','descricao','descrição','mini_bio','sobre');
+    const langs= get('idiomas','languages');
+    const photo= get('foto','foto_url','image','foto_perfil');
+    const contacts = parseContacts(get('contatos','contact','contato','contacts'));
+
+    return {
+      id: cad || slugify(name),
+      name, cadastur: cad, uf, city, bio,
+      languages: langs ? langs.split('|').map(s=>s.trim()).filter(Boolean) : [],
+      photo: photo || 'images/placeholder_guide.png',
+      contacts,
+      slug: `${slugify(name)}-${(cad || '').slice(-4)}`
+    };
+  };
+
+  async function loadData() {
+    if (window.__USE_CSV__) {
+      try {
+        const resp = await fetch('data/cadastur.csv', { cache: 'no-store' });
+        if (resp.ok) {
+          const text = await resp.text();
+          const [header, ...lines] = text.trim().split(/\r?\n/);
+          const cols = header.split(',').map(h=>h.trim());
+          return lines.map(line => {
+            const parts = line.split(',');
+            const obj = {};
+            cols.forEach((c,i)=>obj[c]=parts[i]);
+            return obj;
+          }).map(norm);
         }
-      });
+      } catch(_) {}
     }
-    guide.photo = entry.foto || entry.foto_url || entry.image || entry.foto_perfil || '';
-    guide.image = guide.photo;
-    guide.bio = entry.bio || entry.descricao || entry.descrição || entry.description || '';
-    return guide;
+    return (Array.isArray(window.cadasturData) ? window.cadasturData.map(norm) : []);
   }
 
-  // Extract query params
-  const params = new URLSearchParams(window.location.search);
-  const slugParam = params.get('slug');
-  const idParam = params.get('id');
+  function render(guide) {
+    const langs = guide.languages.length ? `<p><i class="fas fa-language"></i> ${guide.languages.join(', ')}</p>` : '';
+    const contacts = guide.contacts;
+    const contactsHtml = `
+      <ul class="contact-list">
+        ${contacts.whatsapp ? `<li><i class="fab fa-whatsapp"></i> ${contacts.whatsapp}</li>` : ''}
+        ${contacts.instagram ? `<li><i class="fab fa-instagram"></i> @${contacts.instagram}</li>` : ''}
+        ${contacts.email ? `<li><i class="far fa-envelope"></i> ${contacts.email}</li>` : ''}
+        ${(!contacts.whatsapp && !contacts.instagram && !contacts.email) ? '<li>Contatos não informados.</li>' : ''}
+      </ul>
+    `;
 
-  // Find matching guide in the CADASTUR dataset
-  function findGuide() {
-    if (!Array.isArray(window.cadasturData)) return null;
-    // Compute slug for each entry on the fly
-    let entryFound = null;
-    if (slugParam) {
-      // Try direct match based on precomputed slug if exists
-      entryFound = window.cadasturData.find(entry => entry.slug === slugParam);
-      if (!entryFound) {
-        // Fallback: parse slug into name slug and last digits of cadastur
-        const parts = slugParam.split('-');
-        const idPart = parts.pop();
-        const namePart = parts.join('-');
-        window.cadasturData.forEach(entry => {
-          if (entryFound) return;
-          const entryNameSlug = slugify(entry.nome || entry.nome_completo || entry.name || '');
-          const cad = String(entry.numero_cadastur || entry.numero || entry.numero_cad || entry['nº cadastur'] || entry['número cadastur'] || '');
-          if (entryNameSlug === namePart && cad.slice(-idPart.length) === idPart) {
-            entryFound = entry;
-          }
-        });
+    container.innerHTML = `
+      <div class="guide-hero">
+        <img src="${guide.photo}" alt="${guide.name}">
+        <div class="guide-hero-overlay">
+          <h1>${guide.name}</h1>
+          <p><i class="fas fa-certificate" style="color:var(--color-secondary);"></i> ${guide.cadastur || 'Sem Cadastur'}</p>
+          <p><i class="fas fa-map-marker-alt"></i> ${guide.uf || '-'} · ${guide.city || '-'}</p>
+        </div>
+      </div>
+
+      <div class="guide-detail-section">
+        <div class="guide-detail-left">
+          <h2>Sobre</h2>
+          <p>${guide.bio || 'Sem descrição.'}</p>
+          ${langs}
+          <h3>Contato</h3>
+          ${contactsHtml}
+        </div>
+        <div class="guide-detail-right">
+          <h2>Expedições</h2>
+          <div id="guide-exps"></div>
+        </div>
+      </div>
+    `;
+
+    // expedições (opcional: quando sua base real estiver pronta)
+    const expsDiv = document.getElementById('guide-exps');
+    expsDiv.innerHTML = `<p>Nenhuma expedição disponível no momento.</p>`;
+  }
+
+  window.addEventListener('load', async () => {
+    const data = await loadData();
+    const url = new URL(location.href);
+    const viaCad = url.searchParams.get('cadastur');
+    const viaSlug= url.searchParams.get('slug');
+
+    let guide = null;
+
+    if (viaCad) {
+      guide = data.find(g => (g.cadastur||'').toUpperCase() === viaCad.toUpperCase());
+    }
+    if (!guide && viaSlug) {
+      guide = data.find(g => g.slug === viaSlug);
+      if (!guide) {
+        const base = viaSlug.replace(/-\d{3,4}$/, '');
+        const suffix = (viaSlug.match(/-(\d{3,4})$/)||[])[1] || '';
+        guide = data.find(g => slugify(g.name) === base && (g.cadastur||'').endsWith(suffix));
       }
     }
-    // If not found by slug, try by id or cadastur
-    if (!entryFound && idParam) {
-      entryFound = window.cadasturData.find(entry => {
-        const cad = String(entry.numero_cadastur || entry.numero || entry.numero_cad || '');
-        return cad === idParam || String(entry.id) === idParam;
-      });
+
+    if (!guide) {
+      container.innerHTML = '<p>Guia não encontrado.</p>';
+      return;
     }
-    return entryFound;
-  }
-
-  const rawGuide = findGuide();
-  if (!rawGuide) {
-    container.innerHTML = '<p>Guia não encontrado.</p>';
-    return;
-  }
-  const guide = normaliseCadastur(rawGuide);
-
-  // Build HTML for profile
-  let html = '';
-  html += `<h1 class="detail-title">${guide.name}</h1>`;
-  const imgSrc = guide.image || 'images/guia1.png';
-  html += `<img src="${imgSrc}" alt="${guide.name}" class="detail-image" />`;
-  html += '<div class="detail-info">';
-  if (guide.cadastur) html += `<p><strong>Nº Cadastur:</strong> ${guide.cadastur}</p>`;
-  if (guide.uf) html += `<p><strong>Estado:</strong> ${guide.uf}</p>`;
-  if (guide.city) html += `<p><strong>Município:</strong> ${guide.city}</p>`;
-  if (guide.languages && guide.languages.length) html += `<p><strong>Idiomas:</strong> ${guide.languages.join(', ')}</p>`;
-  html += '</div>';
-  html += `<div class="detail-description"><h3>Sobre o Guia</h3><p>${guide.bio}</p></div>`;
-  html += '<div class="detail-contact"><h3>Contato</h3>';
-  if (guide.contacts && guide.contacts.length) {
-    guide.contacts.forEach(({ type, value }) => {
-      html += `<p><strong>${type}:</strong> ${value}</p>`;
-    });
-  } else {
-    html += '<p>Contato não disponível.</p>';
-  }
-  html += '</div>';
-  // Expeditions section
-  let guideExps = [];
-  if (Array.isArray(window.expeditionsData) && guide.cadastur) {
-    // Match guide id or cadastur with expedition.guideId
-    guideExps = window.expeditionsData.filter(exp => {
-      return String(exp.guideId) === String(guide.cadastur) || String(exp.guideId) === String(rawGuide.id);
-    });
-  }
-  if (guideExps.length) {
-    html += '<div class="detail-expeditions"><h3>Expedições deste Guia</h3><div class="expedition-list">';
-    guideExps.forEach(exp => {
-      const spotsLeft = exp.maxPeople - exp.spotsTaken;
-      html += `<div class="expedition-card">
-        <div class="expedition-content">
-          <div class="expedition-title">${exp.title || ''}</div>
-          <div class="expedition-meta">${(exp.startDate || '').replace(/-/g,'/')} - ${(exp.endDate || '').replace(/-/g,'/')} · ${exp.level || ''}</div>
-          <div class="expedition-price">R$ ${exp.price ? exp.price.toFixed(2) : ''} por pessoa</div>
-          <div class="expedition-meta">${spotsLeft} vaga${spotsLeft !== 1 ? 's' : ''} disponível${spotsLeft !== 1 ? 's' : ''}</div>
-          <a href="expedicao.html?id=${exp.id}" class="btn btn-secondary">Ver Expedição</a>
-        </div>
-      </div>`;
-    });
-    html += '</div></div>';
-  } else {
-    html += '<div class="detail-expeditions"><h3>Expedições deste Guia</h3><p>Nenhuma expedição disponível no momento.</p></div>';
-  }
-  container.innerHTML = html;
-});
+    render(guide);
+  });
+})();

--- a/guides_list.js
+++ b/guides_list.js
@@ -1,493 +1,299 @@
-/*
- * Guides list page script for Trekko Brasil
- *
- * This script powers the listagem de guias (guias.html) page. It reads a
- * CSV file of CADASTUR guides, normalises the fields, applies filters,
- * sorting and pagination, and updates the UI accordingly. It also
- * synchronises the state with URL query parameters so that filters and
- * pages can be shared via direct links. A simple contact modal is
- * provided for viewing a guia's phone/email/Instagram. The script is
- * entirely client‑side and does not require a backend.
- */
+/* guides_list.js – Lista de Guias 100% CADASTUR */
 
-document.addEventListener('DOMContentLoaded', () => {
-  // Only run on guides list page
-  if (!document.body.classList.contains('guides-list-page')) return;
+(function () {
+  const grid = document.getElementById('guidesGrid');
+  const countersDiv = document.getElementById('guidesCounters');
+  const stateSel = document.getElementById('filterUF');
+  const citySel  = document.getElementById('filterCity');
+  const searchIn = document.getElementById('searchInput');
+  const sortSel  = document.getElementById('sortSelect');
+  const clearBtn = document.getElementById('clearFilters');
+  const pager    = document.getElementById('pagination');
 
   const pageSize = 30;
-  let allGuides = [];
-  let filteredGuides = [];
+  let allGuides = [];       // dataset normalizado
+  let filtered = [];        // após filtros/busca
   let currentPage = 1;
-  let sortOption = 'name-asc';
-  let searchQuery = '';
-  let selectedState = '';
-  let selectedCity = '';
 
-  // DOM elements
-  const searchInput = document.getElementById('guideSearch');
-  const stateSelect = document.getElementById('guideStateFilter');
-  const citySelect = document.getElementById('guideCityFilter');
-  const sortSelect = document.getElementById('guideSort');
-  const clearBtn = document.getElementById('clearGuideFilters');
-  const countersDiv = document.getElementById('guideCounters');
-  const listDiv = document.getElementById('guideList');
-  const paginationDiv = document.getElementById('pagination');
-  const contactModal = document.getElementById('guideContactModal');
-  const contactContent = document.getElementById('guideContactContent');
-  const contactClose = document.getElementById('guideContactClose');
-
-  /**
-   * Parse a CSV line into an array of values. Handles quoted values
-   * containing commas.
-   * @param {string} line
-   * @returns {string[]}
-   */
-  function parseCSVLine(line) {
-    const result = [];
-    let current = '';
-    let inQuotes = false;
-    for (let i = 0; i < line.length; i++) {
-      const char = line[i];
-      if (char === '"') {
-        // Toggle quotes, unless it's an escaped double quote
-        if (i + 1 < line.length && line[i + 1] === '"') {
-          current += '"';
-          i++;
-        } else {
-          inQuotes = !inQuotes;
-        }
-      } else if (char === ',' && !inQuotes) {
-        result.push(current);
-        current = '';
-      } else {
-        current += char;
-      }
-    }
-    result.push(current);
-    return result;
-  }
-
-  /**
-   * Normalise a raw CSV row object into a guide object with standard
-   * property names. Uses heuristics based on column names.
-   * @param {Object} row
-   * @returns {Object}
-   */
-  function normalizeGuide(row) {
-    const guide = {
-      id: '',
-      name: '',
-      cadastur: '',
-      state: '',
-      city: '',
-      contacts: [],
-      languages: [],
-      photo: '',
-      bio: ''
-    };
-    for (const key in row) {
-      const lower = key.toLowerCase();
-      const val = row[key] ? String(row[key]).trim() : '';
-      if (!val) continue;
-      if (lower.includes('nome')) {
-        guide.name = val;
-      } else if (lower.includes('numero') && lower.includes('cad')) {
-        guide.cadastur = val;
-      } else if (lower.includes('cadastur')) {
-        guide.cadastur = val;
-      } else if (lower.includes('uf') || lower.includes('estado')) {
-        guide.state = val.toUpperCase();
-      } else if (lower.includes('municipio') || lower.includes('município') || lower.includes('cidade')) {
-        guide.city = val;
-      } else if (lower.includes('idioma') || lower.includes('lang')) {
-        guide.languages = val.split(/\||,|;/).map(s => s.trim()).filter(Boolean);
-      } else if (lower.includes('contato') || lower.includes('whats') || lower.includes('insta') || lower.includes('telefone') || lower.includes('email')) {
-        // Split contacts by | or comma
-        const parts = val.split(/\||,/);
-        parts.forEach(part => {
-          const [type, value] = part.split(/[:：]/);
-          if (value) {
-            guide.contacts.push({ type: type.trim(), value: value.trim() });
-          }
-        });
-      } else if (lower.includes('foto') || lower.includes('image')) {
-        guide.photo = val;
-      } else if (lower.includes('bio') || lower.includes('descr')) {
-        guide.bio = val;
-      } else if (lower.includes('id')) {
-        guide.id = val;
-      }
-    }
-    // Fallbacks
-    if (!guide.id) guide.id = guide.cadastur || guide.name.replace(/\s+/g, '-').toLowerCase();
-    return guide;
-  }
-
-  /**
-   * Convert a string into a URL-friendly slug. Normalizes unicode,
-   * removes accents and special characters, lowercases and replaces
-   * whitespace with hyphens. Used to generate slugs for duplicated
-   * guide entries when replicating the dataset.
-   * @param {string} str
-   * @returns {string}
-   */
-  function slugify(str) {
-    return str
-      .toString()
-      .normalize('NFD')
-      .replace(/[\u0300-\u036f]/g, '')
+  // ---- Util ----
+  const slugify = (s) =>
+    (s || '')
+      .normalize('NFD').replace(/[\u0300-\u036f]/g, '')
       .toLowerCase()
       .replace(/[^a-z0-9]+/g, '-')
-      .replace(/^-+|-+$/g, '');
-  }
+      .replace(/(^-|-$)/g, '');
 
-  /**
-   * Populate state options based on all guides.
-   */
-  function populateStateOptions() {
-    const states = Array.from(new Set(allGuides.map(g => g.state).filter(Boolean)));
-    states.sort();
-    // Clear existing except first
-    stateSelect.innerHTML = '<option value="">Todos</option>';
-    states.forEach(s => {
-      const opt = document.createElement('option');
-      opt.value = s;
-      opt.textContent = s;
-      stateSelect.appendChild(opt);
-    });
-  }
+  const parseContacts = (s) => {
+    if (!s) return {};
+    let wpp = (/whats(app)?:\s*([^|]+)/i.exec(s) || [])[2];
+    let ig  = (/insta(gram)?:\s*([^|]+)/i.exec(s) || [])[2];
+    let em  = (/mail|e-?mail:\s*([^|]+)/i.exec(s) || [])[2];
+    return {
+      whatsapp: wpp ? wpp.trim() : '',
+      instagram: ig ? ig.trim().replace(/^@/, '') : '',
+      email: em ? em.trim() : ''
+    };
+  };
 
-  /**
-   * Populate city options based on selected state.
-   * @param {string} state
-   */
-  function populateCityOptions(state) {
-    if (!state) {
-      citySelect.innerHTML = '<option value="">Todas</option>';
-      citySelect.disabled = true;
-      return;
-    }
-    const cities = Array.from(new Set(allGuides.filter(g => g.state === state).map(g => g.city).filter(Boolean)));
-    cities.sort((a, b) => a.localeCompare(b));
-    citySelect.innerHTML = '<option value="">Todas</option>';
-    cities.forEach(c => {
-      const opt = document.createElement('option');
-      opt.value = c;
-      opt.textContent = c;
-      citySelect.appendChild(opt);
-    });
-    citySelect.disabled = false;
-  }
-
-  /**
-   * Read URL parameters and apply to filters. Then apply filters.
-   */
-  function applyFiltersFromURL() {
-    const params = new URLSearchParams(window.location.search);
-    searchQuery = params.get('q') || '';
-    selectedState = params.get('uf') || '';
-    selectedCity = params.get('city') || '';
-    sortOption = params.get('sort') || 'name-asc';
-    const page = parseInt(params.get('page'), 10);
-    currentPage = (!isNaN(page) && page > 0) ? page : 1;
-    // set controls
-    searchInput.value = searchQuery;
-    sortSelect.value = sortOption;
-    populateStateOptions();
-    stateSelect.value = selectedState;
-    populateCityOptions(selectedState);
-    citySelect.value = selectedCity;
-    applyFilters(false);
-  }
-
-  /**
-   * Update URL query parameters based on current filter state.
-   */
-  function updateURLParams() {
-    const params = new URLSearchParams();
-    if (searchQuery) params.set('q', searchQuery);
-    if (selectedState) params.set('uf', selectedState);
-    if (selectedCity) params.set('city', selectedCity);
-    if (sortOption && sortOption !== 'name-asc') params.set('sort', sortOption);
-    if (currentPage > 1) params.set('page', currentPage);
-    const newUrl = window.location.pathname + (params.toString() ? '?' + params.toString() : '');
-    window.history.replaceState({}, '', newUrl);
-  }
-
-  /**
-   * Apply current filters and search to all guides, update filteredGuides, then
-   * render guides and pagination.
-   * @param {boolean} resetPage Whether to reset to page 1
-   */
-  function applyFilters(resetPage = true) {
-    // Save previous state for resetting page if needed
-    if (resetPage) currentPage = 1;
-    // Filter
-    filteredGuides = allGuides.filter(g => {
-      // Search by name or cadastur
-      const q = searchQuery.toLowerCase();
-      const matchesSearch = !q || g.name.toLowerCase().includes(q) || g.cadastur.toLowerCase().includes(q);
-      const matchesState = !selectedState || g.state === selectedState;
-      const matchesCity = !selectedCity || g.city === selectedCity;
-      return matchesSearch && matchesState && matchesCity;
-    });
-    // Sort
-    const [key, direction] = sortOption.split('-');
-    filteredGuides.sort((a, b) => {
-      let valA = '';
-      let valB = '';
-      if (key === 'name') {
-        valA = a.name.toLowerCase();
-        valB = b.name.toLowerCase();
-      } else if (key === 'city') {
-        valA = a.city.toLowerCase();
-        valB = b.city.toLowerCase();
+  // Normaliza uma linha vinda do CSV/JS para shape padrão
+  function normalize(row) {
+    // nomes de coluna variáveis
+    const get = (...keys) => {
+      for (const k of keys) {
+        const v = row[k]; if (v != null && String(v).trim() !== '') return String(v).trim();
       }
-      if (valA < valB) return direction === 'asc' ? -1 : 1;
-      if (valA > valB) return direction === 'asc' ? 1 : -1;
-      return 0;
-    });
-    updateCounters();
-    renderGuides();
-    renderPagination();
-    updateURLParams();
+      return '';
+    };
+
+    const name = get('nome', 'nome_completo', 'name');
+    const cad  = get('numero_cadastur','cadastur','n_cadastur','número_cadastur');
+    const uf   = get('uf','estado','estado_uf');
+    const city = get('municipio','cidade','city');
+    const bio  = get('bio','descricao','descrição','mini_bio','sobre');
+    const langs= get('idiomas','languages');
+    const photo= get('foto','foto_url','image','foto_perfil');
+
+    const contacts = parseContacts(get('contatos','contact','contato','contacts'));
+    const id = cad || (name ? name.toLowerCase().replace(/\s+/g,'-') : '');
+
+    return {
+      id,
+      name,
+      cadastur: cad,
+      uf,
+      city,
+      bio,
+      languages: langs ? langs.split('|').map(s=>s.trim()).filter(Boolean) : [],
+      photo: photo || 'images/placeholder_guide.png',
+      contacts,
+      slug: `${slugify(name)}-${(cad || '').slice(-4)}`
+    };
   }
 
-  /**
-   * Render counters for total and filtered guides.
-   */
-  function updateCounters() {
-    const total = allGuides.length;
-    const filtered = filteredGuides.length;
-    // Determine how many items are displayed on the current page.
-    const startIndex = (currentPage - 1) * pageSize;
-    const displayed = Math.max(0, Math.min(pageSize, filtered - startIndex));
-    countersDiv.textContent = `Mostrando ${displayed} de ${filtered} guias (Total: ${total})`;
-  }
-
-  /**
-   * Render the current page of guides into the listDiv.
-   */
-  function renderGuides() {
-    // Update counters to reflect current page counts
-    updateCounters();
-    listDiv.innerHTML = '';
-    const totalPages = Math.ceil(filteredGuides.length / pageSize) || 1;
-    if (currentPage > totalPages) currentPage = totalPages;
-    const startIndex = (currentPage - 1) * pageSize;
-    const endIndex = Math.min(startIndex + pageSize, filteredGuides.length);
-    if (filteredGuides.length === 0) {
-      const p = document.createElement('p');
-      p.textContent = 'Nenhum guia encontrado com os filtros selecionados.';
-      listDiv.appendChild(p);
-      return;
+  // ---- Carregar dados: CSV (preferência) ou JS (fallback) ----
+  async function loadData() {
+    // Tentar CSV?
+    if (window.__USE_CSV__) {
+      try {
+        const resp = await fetch('data/cadastur.csv', { cache: 'no-store' });
+        if (resp.ok) {
+          const text = await resp.text();
+          const [header, ...lines] = text.trim().split(/\r?\n/);
+          const cols = header.split(',').map(h=>h.trim());
+          const rows = lines.map(line => {
+            // parser leve (atenção: CSV simples — se seu CSV tem vírgulas entre aspas, troque por PapaParse)
+            const parts = line.split(','); 
+            const obj = {};
+            cols.forEach((c,i)=>obj[c]=parts[i]);
+            return obj;
+          });
+          return rows.map(normalize);
+        }
+      } catch (_) { /* ignora e cai no fallback */ }
     }
-    const frag = document.createDocumentFragment();
-    for (let i = startIndex; i < endIndex; i++) {
-      const g = filteredGuides[i];
+    // Fallback: usar dataset JS embutido (window.cadasturData)
+    if (Array.isArray(window.cadasturData)) return window.cadasturData.map(normalize);
+    return [];
+  }
+
+  // ---- Filtros/busca/ordenação ----
+  function applyFilters() {
+    const q = (searchIn.value || '').trim().toLowerCase();
+    const uf = stateSel.value;
+    const city = citySel.value;
+
+    filtered = allGuides.filter(g => {
+      if (uf && g.uf !== uf) return false;
+      if (city && g.city !== city) return false;
+      if (q) {
+        // busca em nome ou Cadastur
+        const hay = (g.name + ' ' + g.cadastur).toLowerCase();
+        if (!hay.includes(q)) return false;
+      }
+      return true;
+    });
+
+    // ordenar
+    const sort = sortSel.value || 'name_asc';
+    const cmp = {
+      'name_asc': (a,b)=> a.name.localeCompare(b.name, 'pt'),
+      'name_desc':(a,b)=> b.name.localeCompare(a.name, 'pt'),
+      'city_asc': (a,b)=> a.city.localeCompare(b.city, 'pt') || a.name.localeCompare(b.name,'pt'),
+      'city_desc':(a,b)=> b.city.localeCompare(a.city, 'pt') || a.name.localeCompare(b.name,'pt')
+    }[sort] || ((a,b)=>0);
+
+    filtered.sort(cmp);
+    currentPage = 1;
+    render();
+    syncURL();
+  }
+
+  function syncURL() {
+    const p = new URLSearchParams();
+    if (searchIn.value) p.set('q', searchIn.value);
+    if (stateSel.value) p.set('uf', stateSel.value);
+    if (citySel.value)  p.set('city', citySel.value);
+    if (sortSel.value)  p.set('sort', sortSel.value);
+    if (currentPage>1)  p.set('page', String(currentPage));
+    history.replaceState(null,'',`?${p.toString()}`);
+  }
+
+  function fromURL() {
+    const u = new URL(location.href);
+    searchIn.value = u.searchParams.get('q') || '';
+    stateSel.value = u.searchParams.get('uf') || '';
+    sortSel.value  = u.searchParams.get('sort') || 'name_asc';
+    // cidade será preenchida após montarmos a lista dinâmica
+    const p = parseInt(u.searchParams.get('page')||'1',10);
+    currentPage = isNaN(p) ? 1 : Math.max(1,p);
+    return u.searchParams.get('city') || '';
+  }
+
+  // ---- UI ----
+  function renderCounters() {
+    const total = allGuides.length;
+    const filteredTotal = filtered.length;
+    const start = (currentPage-1)*pageSize;
+    const showing = Math.min(pageSize, Math.max(filteredTotal - start, 0));
+    countersDiv.textContent = `Mostrando ${showing} de ${filteredTotal} guias (Total: ${total})`;
+  }
+
+  function renderGrid() {
+    grid.innerHTML = '';
+    const start = (currentPage-1)*pageSize;
+    const items = filtered.slice(start, start+pageSize);
+
+    items.forEach(g => {
       const card = document.createElement('div');
       card.className = 'guide-card';
       card.innerHTML = `
-        <div class="guide-photo"><a href="guia.html?slug=${g.slug || ''}"><img src="${g.photo || g.image || 'images/guia1.png'}" alt="${g.name}"></a></div>
+        <div class="guide-photo"><img src="${g.photo}" alt="${g.name}"></div>
         <div class="guide-info">
-          <h3 class="guide-name"><a href="guia.html?slug=${g.slug || ''}">${g.name}</a></h3>
+          <h3 class="guide-name">
+            <a href="guia.html?slug=${encodeURIComponent(g.slug)}" class="guide-link">${g.name}</a>
+          </h3>
           <p class="guide-cad"><i class="fas fa-certificate" style="color:var(--color-secondary);"></i> ${g.cadastur}</p>
-          <p class="guide-location">${g.state || g.uf || ''}${g.city || g.municipio ? ' · ' + (g.city || g.municipio) : ''}</p>
-          ${g.languages && g.languages.length ? `<p class="guide-languages">Idiomas: ${g.languages.join(', ')}</p>` : ''}
-          ${g.bio ? `<p class="guide-bio">${g.bio.length > 200 ? g.bio.slice(0, 200) + '…' : g.bio}</p>` : ''}
+          <p class="guide-loc"><i class="fas fa-map-marker-alt"></i> ${g.uf} • ${g.city}</p>
+          ${g.languages.length ? `<p class="guide-langs"><i class="fas fa-language"></i> ${g.languages.join(', ')}</p>` : ''}
+          ${g.bio ? `<p class="guide-bio">${g.bio.slice(0, 200)}${g.bio.length>200?'…':''}</p>` : ''}
           <div class="guide-actions">
-            <button class="btn btn-outline exp-btn" data-guide-id="${g.id}">Ver Expedições</button>
-            <button class="btn btn-secondary contact-btn" data-guide-id="${g.id}">Contato</button>
+            <a class="btn btn-outline" href="expedicoes.html?guia=${encodeURIComponent(g.cadastur)}">Ver Expedições</a>
+            <button class="btn btn-solid" data-action="contact" data-wpp="${g.contacts.whatsapp||''}" data-ig="${g.contacts.instagram||''}" data-email="${g.contacts.email||''}">Contato</button>
           </div>
         </div>
       `;
-      frag.appendChild(card);
-    }
-    listDiv.appendChild(frag);
-  }
-
-  /**
-   * Render pagination controls.
-   */
-  function renderPagination() {
-    paginationDiv.innerHTML = '';
-    const totalPages = Math.ceil(filteredGuides.length / pageSize) || 1;
-    if (totalPages <= 1) return;
-    const createBtn = (text, page, disabled = false) => {
-      const btn = document.createElement('button');
-      btn.textContent = text;
-      btn.className = 'page-btn' + (disabled ? ' disabled' : '');
-      if (!disabled) {
-        btn.addEventListener('click', () => {
-          currentPage = page;
-          renderGuides();
-          renderPagination();
-          updateURLParams();
-          window.scrollTo({ top: listDiv.offsetTop - 100, behavior: 'smooth' });
-        });
-      }
-      return btn;
-    };
-    // Previous
-    paginationDiv.appendChild(createBtn('Anterior', currentPage - 1, currentPage === 1));
-    // Page numbers: show first, last, and nearby pages
-    const pages = [];
-    for (let p = 1; p <= totalPages; p++) {
-      if (p === 1 || p === totalPages || Math.abs(p - currentPage) <= 2) {
-        pages.push(p);
-      }
-    }
-    let lastPrinted = 0;
-    pages.forEach(p => {
-      if (p - lastPrinted > 1) {
-        const dots = document.createElement('span');
-        dots.textContent = '…';
-        dots.className = 'page-dots';
-        paginationDiv.appendChild(dots);
-      }
-      const btn = createBtn(String(p), p, p === currentPage);
-      if (p === currentPage) btn.classList.add('active');
-      paginationDiv.appendChild(btn);
-      lastPrinted = p;
+      grid.appendChild(card);
     });
-    // Next
-    paginationDiv.appendChild(createBtn('Próxima', currentPage + 1, currentPage === totalPages));
   }
 
-  /**
-   * Open contact modal for the given guide id.
-   * @param {string} id
-   */
-  function openContactModal(id) {
-    const guide = allGuides.find(g => String(g.id) === String(id));
-    if (!guide) return;
-    contactContent.innerHTML = '';
-    const nameEl = document.createElement('h3');
-    nameEl.textContent = guide.name;
-    contactContent.appendChild(nameEl);
-    if (guide.contacts && guide.contacts.length > 0) {
-      guide.contacts.forEach(({ type, value }) => {
-        const p = document.createElement('p');
-        p.innerHTML = `<strong>${type}:</strong> ${value}`;
-        contactContent.appendChild(p);
+  function renderPager() {
+    pager.innerHTML = '';
+    const totalPages = Math.max(1, Math.ceil(filtered.length / pageSize));
+    if (totalPages <= 1) return;
+
+    const addBtn = (label, page, disabled=false, active=false) => {
+      const b = document.createElement('button');
+      b.className = `page-btn${active?' active':''}`;
+      b.textContent = label;
+      b.disabled = disabled;
+      b.addEventListener('click', () => {
+        currentPage = page;
+        render();
+        syncURL();
+        window.scrollTo({top:0, behavior:'smooth'});
       });
-    } else {
-      const p = document.createElement('p');
-      p.textContent = 'Contato não disponível.';
-      contactContent.appendChild(p);
-    }
-    contactModal.classList.add('open');
+      pager.appendChild(b);
+    };
+
+    addBtn('Anterior', Math.max(1, currentPage-1), currentPage===1);
+
+    // números com reticências
+    const tp = totalPages;
+    const pages = new Set([1,2,tp-1,tp,currentPage-1,currentPage,currentPage+1].filter(p=>p>=1&&p<=tp));
+    const sorted = [...pages].sort((a,b)=>a-b);
+    let prev = 0;
+    sorted.forEach(p => {
+      if (p - prev > 1) {
+        const span = document.createElement('span');
+        span.textContent = '…';
+        span.className = 'page-ellipsis';
+        pager.appendChild(span);
+      }
+      addBtn(String(p), p, false, p===currentPage);
+      prev = p;
+    });
+
+    addBtn('Próxima', Math.min(tp, currentPage+1), currentPage===tp);
   }
 
-  // Event listeners for filters
-  searchInput.addEventListener('input', () => {
-    searchQuery = searchInput.value.trim();
-    applyFilters();
-  });
-  stateSelect.addEventListener('change', () => {
-    selectedState = stateSelect.value;
-    // Reset city if state changed
-    selectedCity = '';
-    populateCityOptions(selectedState);
-    citySelect.value = '';
-    applyFilters();
-  });
-  citySelect.addEventListener('change', () => {
-    selectedCity = citySelect.value;
-    applyFilters();
-  });
-  sortSelect.addEventListener('change', () => {
-    sortOption = sortSelect.value;
-    applyFilters(false);
-  });
-  clearBtn.addEventListener('click', () => {
-    searchQuery = '';
-    selectedState = '';
-    selectedCity = '';
-    sortOption = 'name-asc';
-    searchInput.value = '';
-    stateSelect.value = '';
-    populateCityOptions('');
-    citySelect.value = '';
-    sortSelect.value = 'name-asc';
-    currentPage = 1;
-    applyFilters(false);
-  });
-  // Event delegation for guide actions
-  listDiv.addEventListener('click', (e) => {
-    const expBtn = e.target.closest('.exp-btn');
-    const contactBtn = e.target.closest('.contact-btn');
-    if (expBtn) {
-      const id = expBtn.getAttribute('data-guide-id');
-      // Check if there are expeditions for this guide
-      let hasExp = false;
-      if (Array.isArray(window.expeditionsData)) {
-        hasExp = window.expeditionsData.some(exp => String(exp.guideId) === String(id));
-      }
-      if (hasExp) {
-        window.location.href = `expedicoes.html?guideId=${encodeURIComponent(id)}`;
-      } else {
-        alert('Nenhuma expedição disponível no momento');
-      }
-    } else if (contactBtn) {
-      const id = contactBtn.getAttribute('data-guide-id');
-      openContactModal(id);
-    }
-  });
-  // Close contact modal
-  if (contactClose) {
-    contactClose.addEventListener('click', () => contactModal.classList.remove('open'));
+  function render() {
+    renderCounters();
+    renderGrid();
+    renderPager();
   }
-  contactModal.addEventListener('click', (e) => {
-    if (e.target === contactModal) {
-      contactModal.classList.remove('open');
-    }
-  });
 
-  // Load dataset from global variable `window.cadasturData` if available.
-  // If no dataset is defined, display an error. This avoids issues with
-  // fetching local CSV files via the file:// protocol which is not allowed
-  // in many browsers.  The dataset is defined in answer/data/cadastur.js.
-  try {
-    if (Array.isArray(window.cadasturData)) {
-      // Normalize each raw entry from the CSV/Excel into our guide object
-      allGuides = window.cadasturData.map((row) => normalizeGuide(row));
-      // Compute slugs for original guides
-      allGuides.forEach(g => {
-        if (!g.slug) {
-          const base = g.name || '';
-          const cad = g.cadastur || '';
-          g.slug = slugify(base) + '-' + String(cad).slice(-4);
-        }
+  function populateUFs() {
+    const ufs = [...new Set(allGuides.map(g=>g.uf).filter(Boolean))].sort();
+    stateSel.innerHTML = `<option value="">Todos os Estados</option>` + ufs.map(u=>`<option value="${u}">${u}</option>`).join('');
+  }
+
+  function populateCitiesFor(uf, preselect='') {
+    const cities = [...new Set(allGuides.filter(g=>!uf || g.uf===uf).map(g=>g.city).filter(Boolean))].sort((a,b)=>a.localeCompare(b,'pt'));
+    citySel.innerHTML = `<option value="">Todas as Cidades</option>` + cities.map(c=>`<option value="${c}">${c}</option>`).join('');
+    if (preselect) citySel.value = preselect;
+  }
+
+  // ---- Eventos ----
+  function wireEvents() {
+    stateSel.addEventListener('change', () => {
+      populateCitiesFor(stateSel.value, '');
+      applyFilters();
+    });
+    citySel.addEventListener('change', applyFilters);
+    searchIn.addEventListener('input', () => { currentPage=1; applyFilters(); });
+    sortSel.addEventListener('change', applyFilters);
+    clearBtn.addEventListener('click', () => {
+      searchIn.value = '';
+      stateSel.value = '';
+      populateCitiesFor('');
+      citySel.value = '';
+      sortSel.value = 'name_asc';
+      currentPage = 1;
+      applyFilters();
+    });
+
+    // Modal de contato simples
+    document.body.addEventListener('click', (ev) => {
+      const btn = ev.target.closest('button[data-action="contact"]');
+      if (!btn) return;
+      const w = btn.dataset.wpp, ig = btn.dataset.ig, em = btn.dataset.email;
+      let html = '<div class="contact-modal"><div class="contact-card">';
+      html += '<h3>Contato do Guia</h3><ul class="contact-list">';
+      if (w) html += `<li><i class="fab fa-whatsapp"></i> ${w}</li>`;
+      if (ig) html += `<li><i class="fab fa-instagram"></i> @${ig}</li>`;
+      if (em) html += `<li><i class="far fa-envelope"></i> ${em}</li>`;
+      if (!w && !ig && !em) html += `<li>Contatos não informados.</li>`;
+      html += '</ul><button class="btn btn-outline" id="closeContact">Fechar</button></div></div>';
+      const wrap = document.createElement('div');
+      wrap.innerHTML = html;
+      document.body.appendChild(wrap.firstChild);
+      document.getElementById('closeContact').addEventListener('click', ()=> {
+        document.querySelector('.contact-modal')?.remove();
       });
-      // Replicate dataset several times to demonstrate pagination with many
-      // items. This duplicates the guides but assigns unique IDs so that
-      // filters and clicks still behave sensibly. If real data contains
-      // thousands of entries this replication is unnecessary.
-      const original = allGuides.slice();
-      let counter = 1;
-      for (let i = 0; i < 8; i++) { // replicate 8 times -> ~9x original
-        original.forEach(g => {
-          const dup = { ...g };
-          // Append counter to ID and Cadastur to make them unique
-          dup.id = `${g.id}-${counter}`;
-          dup.cadastur = `${g.cadastur}-${counter}`;
-          dup.name = `${g.name} (${counter})`;
-          // Compute slug for the duplicated guide
-          dup.slug = slugify(dup.name) + '-' + String(dup.cadastur).slice(-4);
-          allGuides.push(dup);
-          counter++;
-        });
-      }
-      // Populate state options and apply filters from URL to load initial
-      // view. Without resetting page we keep page number from query param.
-      populateStateOptions();
-      applyFiltersFromURL();
-    } else {
-      throw new Error('cadasturData is not defined');
-    }
-  } catch (err) {
-    console.error('Erro ao carregar dados de guias:', err);
-    listDiv.innerHTML = '<p>Erro ao carregar dados de guias.</p>';
+    });
   }
-});
+
+  // ---- Inicialização ----
+  window.addEventListener('load', async () => {
+    allGuides = await loadData();
+
+    // Preenche filtros a partir da URL
+    const preCity = fromURL();
+
+    populateUFs();
+    populateCitiesFor(stateSel.value, preCity);
+
+    applyFilters();
+    wireEvents();
+  });
+})();

--- a/styles.css
+++ b/styles.css
@@ -87,6 +87,27 @@ a:hover {
   color: #ffffff;
 }
 
+.btn-outline {
+  background-color: transparent;
+  color: var(--color-primary);
+  border: 2px solid var(--color-primary);
+}
+
+.btn-outline:hover {
+  background-color: var(--color-primary);
+  color: #ffffff;
+}
+
+.btn-solid {
+  background-color: var(--color-secondary);
+  color: #ffffff;
+}
+
+.btn-solid:hover {
+  background-color: #d98f42;
+  color: #ffffff;
+}
+
 .hidden {
   display: none !important;
 }
@@ -867,6 +888,20 @@ footer {
   width: 100%;
   height: 180px;
   object-fit: cover;
+  background: #eef1f0;
+}
+
+/* placeholder para fotos de guias ausentes */
+.guide-hero img {
+  object-fit: cover;
+  background: #eef1f0;
+}
+
+.guide-loc,
+.guide-langs {
+  font-size: 0.85rem;
+  color: var(--color-muted);
+  margin-bottom: 0.25rem;
 }
 
 .guide-info {
@@ -946,30 +981,91 @@ footer {
   background-color: var(--color-primary);
   color: #fff;
 }
+
+/* Guide profile */
+.guide-detail-section {
+  display: grid;
+  gap: 2rem;
+}
+
+.guide-hero {
+  position: relative;
+  height: 320px;
+  border-radius: 12px;
+  overflow: hidden;
+  margin-bottom: 2rem;
+  background: #eef1f0;
+}
+
+.guide-hero-overlay {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(180deg, rgba(14, 33, 40, 0.15) 0%, rgba(14, 33, 40, 0.75) 100%);
+  color: #ffffff;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  padding: 2rem;
+  gap: 0.5rem;
+}
+
+.guide-detail-left,
+.guide-detail-right {
+  background: #ffffff;
+  border-radius: 12px;
+  padding: 2rem;
+  box-shadow: 0 10px 25px rgba(14, 33, 40, 0.08);
+}
+
+.contact-list {
+  list-style: none;
+  padding: 0;
+  margin: 1rem 0 0;
+  display: grid;
+  gap: 0.5rem;
+  color: var(--color-dark);
+}
+
+.contact-list li {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.contact-list i {
+  color: var(--color-secondary);
+}
+
+.contact-modal {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.45);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1.5rem;
+  z-index: 2000;
+}
+
+.contact-card {
+  background: #ffffff;
+  border-radius: 12px;
+  padding: 1.5rem;
+  width: min(90%, 360px);
+  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.18);
+}
+
+@media (min-width: 900px) {
+  .guide-detail-section {
+    grid-template-columns: 2fr 1fr;
+  }
+}
 .page-dots {
   font-size: 0.85rem;
   color: var(--color-muted);
   padding: 0 0.5rem;
 }
 
-/* Contact modal specific */
-#guideContactModal .modal-content {
-  background-color: #fff;
-  padding: 1.5rem;
-  border-radius: 8px;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
-}
-#guideContactModal h3 {
-  font-family: 'Sora', sans-serif;
-  font-size: 1.3rem;
-  margin-bottom: 0.5rem;
-  color: var(--color-primary);
-}
-#guideContactModal p {
-  font-size: 0.9rem;
-  color: var(--color-dark);
-  margin-bottom: 0.25rem;
-}
 .user-button {
   background: none;
   border: none;


### PR DESCRIPTION
## Summary
- alinhar guias.html aos novos filtros e carregar dados apenas do CADASTUR, ativando suporte a CSV com fallback em JS
- reescrever guides_list.js para normalizar CADASTUR, aplicar filtros/ordenação/paginação e exibir contatos com modal dinâmico
- substituir guide_profile.js e guia.html para consumir somente CADASTUR, compartilhando normalização e layout atualizado
- atualizar estilos globais para novos botões, placeholders de fotos e layout do perfil/modal de contato

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dac4a567548324a87ae93a7fca4950