### PR TITLE
Implement CADASTUR guide ingestion and frontend directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+.tests/
+.next/
+tests/dist/

--- a/components/guides/GuideCard.tsx
+++ b/components/guides/GuideCard.tsx
@@ -1,0 +1,120 @@
+import Link from 'next/link'
+import React, { useMemo, useState } from 'react'
+import type { Guide } from '../../types/guide'
+
+interface GuideCardProps {
+  guide: Guide
+}
+
+const contactIconClasses =
+  'h-10 w-10 flex items-center justify-center rounded-full bg-white text-trekko-blue border border-trekko-blue hover:bg-trekko-blue hover:text-white focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-trekko-yellow transition'
+
+const WhatsappIcon = () => (
+  <svg viewBox="0 0 32 32" fill="currentColor" aria-hidden="true" className="h-5 w-5">
+    <path d="M16 3C9.4 3 4 8.3 4 15c0 2.7.9 5.1 2.5 7.1L5 29l7.1-1.5C13.9 28.4 15 28.6 16 28.6c6.6 0 12-5.3 12-11.9C28 8.3 22.6 3 16 3zm-.1 22.1c-.9 0-1.8-.2-2.7-.5l-.3-.1-4.2.9.9-4.1-.2-.3c-1.4-1.8-2.1-3.9-2.1-6.1 0-5.4 4.4-9.7 9.7-9.7s9.7 4.4 9.7 9.7c.1 5.4-4.3 9.7-9.8 9.7zm5.3-7.1c-.3-.2-1.8-.9-2.1-1-.3-.1-.5-.2-.7.2-.2.3-.8 1-.9 1.1-.2.2-.3.2-.6.1-.3-.2-1.2-.5-2.3-1.5-.8-.7-1.3-1.6-1.5-1.9-.2-.3 0-.5.1-.6.1-.1.3-.3.4-.5.1-.2.2-.3.3-.5.1-.2.1-.3 0-.5-.1-.2-.7-1.7-.9-2.3-.2-.6-.5-.5-.7-.5h-.6c-.2 0-.5.1-.8.3-.3.2-1.1 1-1.1 2.4s1.1 2.8 1.2 3c.2.3 2.2 3.4 5.3 4.7.7.3 1.2.5 1.6.6.7.2 1.3.2 1.8.1.6-.1 1.8-.7 2-1.4.3-.7.3-1.2.2-1.4-.1-.2-.3-.3-.6-.5z" />
+  </svg>
+)
+
+const InstagramIcon = () => (
+  <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true" className="h-5 w-5">
+    <path d="M7 2C4.243 2 2 4.243 2 7v10c0 2.757 2.243 5 5 5h10c2.757 0 5-2.243 5-5V7c0-2.757-2.243-5-5-5H7zm0 2h10c1.654 0 3 1.346 3 3v10c0 1.654-1.346 3-3 3H7c-1.654 0-3-1.346-3-3V7c0-1.654 1.346-3 3-3zm11 1a1 1 0 100 2 1 1 0 000-2zM12 7a5 5 0 100 10 5 5 0 000-10zm0 2a3 3 0 110 6 3 3 0 010-6z" />
+  </svg>
+)
+
+const initialsFromName = (name: string) => {
+  const parts = name.trim().split(/\s+/)
+  if (parts.length === 0) return '??'
+  if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase()
+  return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase()
+}
+
+export const GuideCard: React.FC<GuideCardProps> = ({ guide }) => {
+  const [imageError, setImageError] = useState(false)
+
+  const whatsappUrl = useMemo(() => {
+    if (!guide.whatsapp) return null
+    const digits = guide.whatsapp.replace(/\D+/g, '')
+    return digits ? `https://wa.me/${digits}` : null
+  }, [guide.whatsapp])
+
+  const instagramUrl = useMemo(() => {
+    if (!guide.instagram) return null
+    return `https://instagram.com/${guide.instagram}`
+  }, [guide.instagram])
+
+  const initials = useMemo(() => initialsFromName(guide.nome_completo), [guide.nome_completo])
+  const hasPhoto = Boolean(guide.foto_url && !imageError)
+
+  return (
+    <article className="group flex flex-col rounded-xl border border-gray-200 bg-white shadow-sm transition hover:-translate-y-1 hover:shadow-lg focus-within:-translate-y-1 focus-within:shadow-lg">
+      <div className="relative aspect-[4/3] overflow-hidden rounded-t-xl bg-trekko-sand">
+        {hasPhoto ? (
+          <img
+            src={guide.foto_url ?? ''}
+            alt={`Foto de ${guide.nome_completo}`}
+            loading="lazy"
+            className="h-full w-full object-cover"
+            onError={() => setImageError(true)}
+          />
+        ) : (
+          <div className="flex h-full w-full items-center justify-center bg-gradient-to-br from-trekko-sand to-trekko-yellow text-3xl font-semibold text-trekko-blue" aria-hidden="true">
+            {initials}
+          </div>
+        )}
+      </div>
+
+      <div className="flex flex-1 flex-col gap-4 p-5">
+        <div>
+          <Link href={`/guias/${encodeURIComponent(guide.cadastur)}`} className="text-xl font-semibold text-trekko-blue hover:text-trekko-green focus:text-trekko-green focus:outline-none" data-cadastur={guide.cadastur}>
+            {guide.nome_completo}
+          </Link>
+          <p className="mt-1 text-sm text-gray-600">
+            {guide.municipio} / {guide.uf}
+          </p>
+          <p className="mt-1 text-xs uppercase tracking-wide text-gray-500">Cadastur: {guide.cadastur}</p>
+        </div>
+
+        <p className="text-sm text-gray-700">
+          {guide.bio ?? 'Guia CADASTUR credenciado disponível no Trekko.'}
+        </p>
+
+        <div className="mt-auto flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            {whatsappUrl && (
+              <a
+                href={whatsappUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className={contactIconClasses}
+                title="Conversar no WhatsApp"
+                aria-label="Conversar no WhatsApp"
+              >
+                <WhatsappIcon />
+              </a>
+            )}
+            {instagramUrl && (
+              <a
+                href={instagramUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className={contactIconClasses}
+                title="Ver Instagram"
+                aria-label="Ver Instagram"
+              >
+                <InstagramIcon />
+              </a>
+            )}
+          </div>
+          <Link
+            href={`/guias/${encodeURIComponent(guide.cadastur)}`}
+            className="inline-flex items-center gap-2 rounded-full bg-trekko-blue px-4 py-2 text-sm font-semibold text-white hover:bg-trekko-green focus:bg-trekko-green focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-trekko-yellow"
+          >
+            Ver perfil
+          </Link>
+        </div>
+      </div>
+    </article>
+  )
+}
+
+export default GuideCard

--- a/components/guides/GuideFilters.tsx
+++ b/components/guides/GuideFilters.tsx
@@ -1,0 +1,152 @@
+import React from 'react'
+
+export interface GuideFilterState {
+  uf: string
+  municipio: string
+  nome: string
+  cadastur: string
+  sort: string
+}
+
+interface GuideFiltersProps {
+  filters: GuideFilterState
+  onChange: (field: keyof GuideFilterState, value: string) => void
+  onSubmit: () => void
+  onReset: () => void
+  ufOptions: string[]
+  municipioOptions: string[]
+  isLoadingMunicipios?: boolean
+}
+
+export const GuideFilters: React.FC<GuideFiltersProps> = ({
+  filters,
+  onChange,
+  onSubmit,
+  onReset,
+  ufOptions,
+  municipioOptions,
+  isLoadingMunicipios
+}) => {
+  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    onSubmit()
+  }
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className="mb-8 grid gap-4 rounded-xl border border-gray-200 bg-white p-6 shadow-sm"
+      aria-label="Filtros para buscar guias"
+    >
+      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+        <div>
+          <label htmlFor="filterUf" className="block text-sm font-medium text-gray-700">
+            UF
+          </label>
+          <select
+            id="filterUf"
+            name="uf"
+            value={filters.uf}
+            onChange={(event) => onChange('uf', event.target.value)}
+            className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-trekko-yellow"
+          >
+            <option value="">Todas</option>
+            {ufOptions.map((uf) => (
+              <option key={uf} value={uf}>
+                {uf}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div>
+          <label htmlFor="filterMunicipio" className="block text-sm font-medium text-gray-700">
+            Município
+          </label>
+          <select
+            id="filterMunicipio"
+            name="municipio"
+            value={filters.municipio}
+            onChange={(event) => onChange('municipio', event.target.value)}
+            className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-trekko-yellow"
+            disabled={!filters.uf || isLoadingMunicipios}
+          >
+            <option value="">Todos</option>
+            {municipioOptions.map((city) => (
+              <option key={city} value={city}>
+                {city}
+              </option>
+            ))}
+          </select>
+          {filters.uf && isLoadingMunicipios && <p className="mt-1 text-xs text-gray-500">Carregando municípios…</p>}
+        </div>
+
+        <div>
+          <label htmlFor="filterNome" className="block text-sm font-medium text-gray-700">
+            Nome do guia
+          </label>
+          <input
+            id="filterNome"
+            name="nome"
+            type="text"
+            value={filters.nome}
+            onChange={(event) => onChange('nome', event.target.value)}
+            placeholder="Ex.: Ana"
+            className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-trekko-yellow"
+          />
+        </div>
+
+        <div>
+          <label htmlFor="filterCadastur" className="block text-sm font-medium text-gray-700">
+            Nº Cadastur
+          </label>
+          <input
+            id="filterCadastur"
+            name="cadastur"
+            type="text"
+            value={filters.cadastur}
+            onChange={(event) => onChange('cadastur', event.target.value)}
+            placeholder="Digite o número completo"
+            className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-trekko-yellow"
+          />
+        </div>
+
+        <div>
+          <label htmlFor="filterSort" className="block text-sm font-medium text-gray-700">
+            Ordenar por
+          </label>
+          <select
+            id="filterSort"
+            name="sort"
+            value={filters.sort}
+            onChange={(event) => onChange('sort', event.target.value)}
+            className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-trekko-yellow"
+          >
+            <option value="nome_asc">Nome (A-Z)</option>
+            <option value="nome_desc">Nome (Z-A)</option>
+            <option value="municipio_asc">Município (A-Z)</option>
+            <option value="uf_asc">UF (A-Z)</option>
+          </select>
+        </div>
+      </div>
+
+      <div className="flex flex-wrap items-center gap-3">
+        <button
+          type="submit"
+          className="inline-flex items-center rounded-md bg-trekko-blue px-4 py-2 text-sm font-semibold text-white hover:bg-trekko-green focus:bg-trekko-green focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-trekko-yellow"
+        >
+          Aplicar filtros
+        </button>
+        <button
+          type="button"
+          onClick={onReset}
+          className="inline-flex items-center rounded-md border border-gray-300 px-4 py-2 text-sm font-semibold text-trekko-blue hover:bg-trekko-yellow/10 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-trekko-yellow"
+        >
+          Limpar
+        </button>
+      </div>
+    </form>
+  )
+}
+
+export default GuideFilters

--- a/components/guides/Pagination.tsx
+++ b/components/guides/Pagination.tsx
@@ -1,0 +1,101 @@
+import React from 'react'
+
+interface PaginationProps {
+  currentPage: number
+  totalPages: number
+  onPageChange: (page: number) => void
+  disabled?: boolean
+}
+
+const getPages = (current: number, total: number) => {
+  const pages: number[] = []
+  const delta = 2
+  let start = Math.max(1, current - delta)
+  let end = Math.min(total, current + delta)
+
+  if (current <= delta) {
+    end = Math.min(total, 1 + delta * 2)
+  }
+  if (current + delta >= total) {
+    start = Math.max(1, total - delta * 2)
+  }
+
+  for (let page = start; page <= end; page += 1) {
+    pages.push(page)
+  }
+  return pages
+}
+
+export const Pagination: React.FC<PaginationProps> = ({ currentPage, totalPages, onPageChange, disabled }) => {
+  if (totalPages <= 1) return null
+
+  const pages = getPages(currentPage, totalPages)
+  const isFirst = currentPage === 1
+  const isLast = currentPage === totalPages
+
+  const handleChange = (page: number) => () => {
+    if (!disabled && page !== currentPage) {
+      onPageChange(page)
+    }
+  }
+
+  const buttonClasses = (active: boolean) =>
+    `min-w-[40px] rounded-full border px-3 py-2 text-sm font-medium transition focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-trekko-yellow ${
+      active
+        ? 'bg-trekko-blue text-white border-trekko-blue'
+        : 'bg-white text-trekko-blue border-gray-300 hover:bg-trekko-yellow/10'
+    }`
+
+  return (
+    <nav className="mt-8 flex flex-wrap items-center justify-center gap-2" aria-label="Paginação de guias">
+      <button
+        type="button"
+        className="rounded-full border border-gray-300 px-3 py-2 text-sm font-medium text-trekko-blue hover:bg-trekko-yellow/10 disabled:cursor-not-allowed disabled:opacity-50"
+        onClick={handleChange(1)}
+        disabled={isFirst || disabled}
+      >
+        « Primeira
+      </button>
+      <button
+        type="button"
+        className="rounded-full border border-gray-300 px-3 py-2 text-sm font-medium text-trekko-blue hover:bg-trekko-yellow/10 disabled:cursor-not-allowed disabled:opacity-50"
+        onClick={handleChange(currentPage - 1)}
+        disabled={isFirst || disabled}
+      >
+        ‹ Anterior
+      </button>
+
+      {pages.map((page) => (
+        <button
+          key={page}
+          type="button"
+          onClick={handleChange(page)}
+          className={buttonClasses(page === currentPage)}
+          aria-current={page === currentPage ? 'page' : undefined}
+          disabled={disabled}
+        >
+          {page}
+        </button>
+      ))}
+
+      <button
+        type="button"
+        className="rounded-full border border-gray-300 px-3 py-2 text-sm font-medium text-trekko-blue hover:bg-trekko-yellow/10 disabled:cursor-not-allowed disabled:opacity-50"
+        onClick={handleChange(currentPage + 1)}
+        disabled={isLast || disabled}
+      >
+        Próxima ›
+      </button>
+      <button
+        type="button"
+        className="rounded-full border border-gray-300 px-3 py-2 text-sm font-medium text-trekko-blue hover:bg-trekko-yellow/10 disabled:cursor-not-allowed disabled:opacity-50"
+        onClick={handleChange(totalPages)}
+        disabled={isLast || disabled}
+      >
+        Última »
+      </button>
+    </nav>
+  )
+}
+
+export default Pagination

--- a/lib/cadastur.ts
+++ b/lib/cadastur.ts
@@ -1,0 +1,196 @@
+import type { Prisma } from '@prisma/client'
+
+export const REQUIRED_CSV_COLUMNS = [
+  'nome_completo',
+  'cadastur',
+  'uf',
+  'municipio',
+  'whatsapp',
+  'instagram',
+  'foto_url',
+  'bio'
+] as const
+
+export type CadasturCsvRecord = Record<(typeof REQUIRED_CSV_COLUMNS)[number], string | undefined>
+
+export interface NormalizedGuideRecord {
+  cadastur: string
+  nome_completo: string
+  uf: string
+  municipio: string
+  whatsapp: string | null
+  instagram: string | null
+  foto_url: string | null
+  bio: string | null
+}
+
+export const DEFAULT_PAGE_SIZE = Number(process.env.GUIDES_PAGE_SIZE ?? 30)
+export const MAX_PAGE_SIZE = 50
+
+export type GuideSortKey = 'nome_asc' | 'nome_desc' | 'municipio_asc' | 'uf_asc'
+
+const TITLE_EXCEPTIONS = new Set(['da', 'de', 'do', 'das', 'dos', 'e'])
+
+export const toTitleCase = (value: string | undefined | null) => {
+  if (!value) return ''
+  const trimmed = value.trim()
+  if (!trimmed) return ''
+  return trimmed
+    .toLocaleLowerCase('pt-BR')
+    .split(/\s+/)
+    .map((segment, index) =>
+      segment
+        .split('-')
+        .map((piece, pieceIndex) => {
+          const lower = piece.trim()
+          if (!lower) return ''
+          const shouldCapitalize = index === 0 && pieceIndex === 0 ? true : !TITLE_EXCEPTIONS.has(lower)
+          if (!shouldCapitalize) {
+            return lower
+          }
+          return lower.charAt(0).toLocaleUpperCase('pt-BR') + lower.slice(1)
+        })
+        .join('-')
+    )
+    .join(' ')
+}
+
+export const sanitizeInstagramHandle = (value: string | undefined | null) => {
+  if (!value) return null
+  const trimmed = value.trim()
+  if (!trimmed) return null
+  const handle = trimmed
+    .replace(/^https?:\/\/www\.instagram\.com\//i, '')
+    .replace(/^https?:\/\/instagram\.com\//i, '')
+    .replace(/^@/, '')
+    .split(/[/?#]/)[0]
+  return handle ? handle : null
+}
+
+export const sanitizeWhatsapp = (value: string | undefined | null) => {
+  if (!value) return null
+  const digits = value.replace(/\D+/g, '')
+  if (!digits) return null
+
+  let normalized = digits
+  if (normalized.startsWith('00')) {
+    normalized = normalized.slice(2)
+  }
+  if (normalized.startsWith('0')) {
+    normalized = normalized.replace(/^0+/, '')
+  }
+
+  if (normalized.length === 11) {
+    // Assume Brazilian national number missing country code
+    normalized = `55${normalized}`
+  }
+
+  if (!normalized.startsWith('55') && normalized.length === 10) {
+    // US-like without country code
+    normalized = `1${normalized}`
+  }
+
+  if (normalized.length < 10 || normalized.length > 15) {
+    return null
+  }
+
+  return `+${normalized}`
+}
+
+export const normalizeGuideRecord = (record: CadasturCsvRecord): NormalizedGuideRecord | null => {
+  const cadastur = (record.cadastur ?? '').trim()
+  const nome = toTitleCase(record.nome_completo)
+  const uf = (record.uf ?? '').trim().toUpperCase()
+  const municipio = toTitleCase(record.municipio)
+
+  if (!cadastur || !nome || uf.length !== 2 || !municipio) {
+    return null
+  }
+
+  return {
+    cadastur,
+    nome_completo: nome,
+    uf,
+    municipio,
+    whatsapp: sanitizeWhatsapp(record.whatsapp),
+    instagram: sanitizeInstagramHandle(record.instagram),
+    foto_url: record.foto_url?.trim() || null,
+    bio: record.bio?.trim() || null
+  }
+}
+
+export interface GuideQueryParams {
+  uf?: string
+  municipio?: string
+  nome?: string
+  cadastur?: string
+  page?: string | number
+  pageSize?: string | number
+  sort?: string
+}
+
+export interface GuideQueryOptions {
+  where: Prisma.CadasturGuideWhereInput
+  orderBy: Prisma.CadasturGuideOrderByWithRelationInput
+  skip: number
+  take: number
+  page: number
+  pageSize: number
+  sort: GuideSortKey
+}
+
+const SORT_MAP: Record<GuideSortKey, Prisma.CadasturGuideOrderByWithRelationInput> = {
+  nome_asc: { nomeCompleto: 'asc' },
+  nome_desc: { nomeCompleto: 'desc' },
+  municipio_asc: { municipio: 'asc' },
+  uf_asc: { uf: 'asc' }
+}
+
+export const buildGuideQueryOptions = (params: GuideQueryParams): GuideQueryOptions => {
+  const sortKey = (params.sort as GuideSortKey) ?? 'nome_asc'
+  const sort = SORT_MAP[sortKey] ? (params.sort as GuideSortKey) : 'nome_asc'
+
+  let page = Number(params.page ?? 1)
+  if (Number.isNaN(page) || page < 1) page = 1
+
+  let pageSize = Number(params.pageSize ?? DEFAULT_PAGE_SIZE)
+  if (Number.isNaN(pageSize) || pageSize < 1) pageSize = DEFAULT_PAGE_SIZE
+  pageSize = Math.min(pageSize, MAX_PAGE_SIZE)
+
+  const where: Prisma.CadasturGuideWhereInput = {}
+
+  if (params.uf) {
+    where.uf = params.uf.toString().trim().toUpperCase()
+  }
+
+  if (params.municipio) {
+    where.municipio = {
+      contains: params.municipio.toString().trim(),
+      mode: 'insensitive'
+    }
+  }
+
+  if (params.nome) {
+    where.nomeCompleto = {
+      contains: params.nome.toString().trim(),
+      mode: 'insensitive'
+    }
+  }
+
+  if (params.cadastur) {
+    where.cadastur = params.cadastur.toString().trim()
+  }
+
+  const skip = (page - 1) * pageSize
+  const take = pageSize
+
+  return {
+    where,
+    orderBy: SORT_MAP[sort],
+    skip,
+    take,
+    page,
+    pageSize,
+    sort
+  }
+}

--- a/lib/prisma.ts
+++ b/lib/prisma.ts
@@ -1,0 +1,15 @@
+import { PrismaClient } from '@prisma/client'
+
+const globalForPrisma = globalThis as unknown as { prisma: PrismaClient | undefined }
+
+export const prisma =
+  globalForPrisma.prisma ??
+  new PrismaClient({
+    log: ['error', 'warn']
+  })
+
+if (process.env.NODE_ENV !== 'production') {
+  globalForPrisma.prisma = prisma
+}
+
+export default prisma

--- a/lib/rateLimit.ts
+++ b/lib/rateLimit.ts
@@ -1,0 +1,33 @@
+export interface RateLimitResult {
+  allowed: boolean
+  remaining: number
+  reset: number
+  limit: number
+}
+
+const RATE_LIMIT_WINDOW_MS = Number(process.env.GUIDES_RATE_WINDOW_MS ?? 60_000)
+const RATE_LIMIT_MAX = Number(process.env.GUIDES_RATE_LIMIT ?? 180)
+
+const buckets = new Map<string, { count: number; expiresAt: number }>()
+
+export const checkRateLimit = (
+  identifier: string,
+  limit: number = RATE_LIMIT_MAX,
+  windowMs: number = RATE_LIMIT_WINDOW_MS
+): RateLimitResult => {
+  const now = Date.now()
+  const bucket = buckets.get(identifier)
+
+  if (!bucket || bucket.expiresAt <= now) {
+    buckets.set(identifier, { count: 1, expiresAt: now + windowMs })
+    return { allowed: true, remaining: Math.max(0, limit - 1), reset: now + windowMs, limit }
+  }
+
+  if (bucket.count >= limit) {
+    return { allowed: false, remaining: 0, reset: bucket.expiresAt, limit }
+  }
+
+  bucket.count += 1
+  buckets.set(identifier, bucket)
+  return { allowed: true, remaining: Math.max(0, limit - bucket.count), reset: bucket.expiresAt, limit }
+}

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -2,3 +2,4 @@
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "export": "next build && next export"
+    "export": "next build && next export",
+    "test": "tsc -p tsconfig.tests.json && node tests/dist/tests/cadastur.test.js"
   },
   "dependencies": {
     "next": "14.2.6",

--- a/pages/admin/guides/import.tsx
+++ b/pages/admin/guides/import.tsx
@@ -1,125 +1,147 @@
 import React, { useState } from 'react'
-import Papa from 'papaparse'
+
+interface ImportSummary {
+  inserted: number
+  updated: number
+  discarded: number
+  totalValid: number
+  errors?: string[]
+}
 
 export default function GuideImport() {
-  const [columns, setColumns] = useState<string[]>([])
-  const [data, setData] = useState<any[]>([])
-  const [mapping, setMapping] = useState<{ [key: string]: string }>({})
-  const [preview, setPreview] = useState<any[]>([])
-  const [duplicateCadastur, setDuplicateCadastur] = useState<string[]>([])
-  const [errors, setErrors] = useState<string[]>([])
-  const [step, setStep] = useState<'upload' | 'mapping' | 'preview' | 'commit'>('upload')
+  const [file, setFile] = useState<File | null>(null)
+  const [status, setStatus] = useState<'idle' | 'uploading' | 'success' | 'error'>('idle')
+  const [summary, setSummary] = useState<ImportSummary | null>(null)
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
 
-  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const f = e.target.files?.[0]
-    if (!f) return
-    Papa.parse(f, {
-      header: true,
-      skipEmptyLines: true,
-      complete: (results: any) => {
-        setColumns(results.meta.fields as string[])
-        setData(results.data as any[])
-        setPreview((results.data as any[]).slice(0, 5))
-        setStep('mapping')
-      },
-      error: (err: any) => setErrors([err.message])
-    })
-  }
-
-  const handleMappingChange = (fieldKey: string, column: string) => {
-    setMapping((prev) => ({ ...prev, [fieldKey]: column }))
-  }
-
-  const runDryRun = () => {
-    const missing = ['cadastur', 'name'].filter((k) => !mapping[k])
-    if (missing.length > 0) {
-      setErrors([`Mapeie os campos obrigatórios: ${missing.join(', ')}`])
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    if (!file) {
+      setErrorMessage('Selecione um arquivo CSV do Cadastur antes de enviar.')
       return
     }
-    setErrors([])
-    const cadasturValues: Record<string, number> = {}
-    const duplicates: string[] = []
-    data.forEach((row) => {
-      const cad = row[mapping['cadastur']]
-      if (cad) cadasturValues[cad] = (cadasturValues[cad] || 0) + 1
-    })
-    Object.keys(cadasturValues).forEach((cad) => {
-      if (cadasturValues[cad] > 1) duplicates.push(cad)
-    })
-    setDuplicateCadastur(duplicates)
-    setStep('preview')
+
+    setStatus('uploading')
+    setErrorMessage(null)
+    setSummary(null)
+
+    const formData = new FormData()
+    formData.append('file', file)
+
+    try {
+      const response = await fetch('/api/admin/cadastur/upload', {
+        method: 'POST',
+        body: formData
+      })
+
+      if (!response.ok) {
+        const payload = await response.json().catch(() => ({ error: 'Erro desconhecido' })) as {
+          error?: string
+          details?: unknown
+        }
+        setErrorMessage(payload.error || 'Não foi possível importar o arquivo.')
+        if (Array.isArray(payload.details)) {
+          setSummary({ inserted: 0, updated: 0, discarded: payload.details.length, totalValid: 0, errors: payload.details })
+        }
+        setStatus('error')
+        return
+      }
+
+      const payload = (await response.json()) as ImportSummary
+      setSummary(payload)
+      setStatus('success')
+    } catch (error) {
+      console.error('Erro ao enviar CSV', error)
+      setErrorMessage('Erro inesperado ao enviar o arquivo. Tente novamente.')
+      setStatus('error')
+    }
   }
 
-  const commit = () => {
-    alert('Importação confirmada! (stub)')
-    setStep('commit')
+  const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const selected = event.target.files?.[0] ?? null
+    setFile(selected)
+    setSummary(null)
+    setErrorMessage(null)
+    setStatus('idle')
   }
 
   return (
-    <div className="max-w-4xl mx-auto py-8 px-4">
-      <h1 className="text-3xl font-bold mb-4">Importar Guias (Cadastur)</h1>
-      {step === 'upload' && (
-        <div className="space-y-4">
-          <p>Faça upload do arquivo CSV exportado do Cadastur.</p>
-          <input type="file" accept=".csv,text/csv" onChange={handleFileChange} className="border p-2" />
-          {errors.length > 0 && <div className="text-red-600">{errors.map((e) => <p key={e}>{e}</p>)}</div>}
-        </div>
-      )}
-      {step === 'mapping' && (
-        <div className="space-y-4">
-          <p>Mapeie as colunas do CSV com os campos do sistema.</p>
-          {['cadastur', 'name', 'email', 'phone', 'uf', 'city', 'validity', 'specialties'].map((field) => (
-            <div key={field} className="flex items-center gap-2">
-              <label className="w-32 capitalize">{field}</label>
-              <select
-                value={mapping[field] || ''}
-                onChange={(e) => handleMappingChange(field, e.target.value)}
-                className="border p-2 flex-1"
-              >
-                <option value="">Selecione...</option>
-                {columns.map((col) => <option key={col} value={col}>{col}</option>)}
-              </select>
-            </div>
-          ))}
-          <button onClick={runDryRun} className="mt-4 bg-trekko-yellow text-black hover:brightness-95 px-4 py-2 rounded">
-            Dry Run
-          </button>
-          {errors.length > 0 && <div className="text-red-600">{errors.map((e) => <p key={e}>{e}</p>)}</div>}
-        </div>
-      )}
-      {step === 'preview' && (
-        <div className="space-y-4">
-          <h2 className="text-2xl font-semibold">Pré-visualização</h2>
-          {duplicateCadastur.length > 0 && <div className="text-red-600"><p>Cadastur duplicados: {duplicateCadastur.join(', ')}</p></div>}
-          <div className="overflow-auto border">
-            <table className="min-w-full divide-y divide-gray-200">
-              <thead className="bg-gray-50">
-                <tr>
-                  {['cadastur', 'name', 'email', 'phone', 'uf', 'city', 'validity', 'specialties'].map((field) => (
-                    <th key={field} className="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">{field}</th>
-                  ))}
-                </tr>
-              </thead>
-              <tbody className="bg-white divide-y divide-gray-200">
-                {preview.map((row, idx) => (
-                  <tr key={idx} className={duplicateCadastur.includes(row[mapping['cadastur']]) ? 'bg-red-50' : ''}>
-                    {['cadastur', 'name', 'email', 'phone', 'uf', 'city', 'validity', 'specialties'].map((field) => (
-                      <td key={field} className="px-4 py-2 whitespace-nowrap text-sm text-gray-700">{row[mapping[field]] || ''}</td>
-                    ))}
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-          <button onClick={commit} className="bg-trekko-yellow text-black hover:brightness-95 px-4 py-2 rounded">
-            Importar
-          </button>
-        </div>
-      )}
-      {step === 'commit' && (
+    <div className="max-w-3xl mx-auto py-10 px-4">
+      <h1 className="text-3xl font-bold text-trekko-blue mb-2">Importar Guias CADASTUR</h1>
+      <p className="text-gray-700 mb-6">
+        Faça upload do CSV oficial do CADASTUR para atualizar a base de guias. As colunas obrigatórias são{' '}
+        <strong>nome_completo</strong>, <strong>cadastur</strong>, <strong>uf</strong>, <strong>municipio</strong>,{' '}
+        <strong>whatsapp</strong>, <strong>instagram</strong>, <strong>foto_url</strong> e <strong>bio</strong>.
+      </p>
+
+      <form onSubmit={handleSubmit} className="space-y-4 bg-white shadow rounded-lg p-6">
         <div>
-          <h2 className="text-2xl font-semibold">Importação concluída!</h2>
-          <p>Os guias foram importados com sucesso.</p>
+          <label htmlFor="cadasturCsv" className="block text-sm font-medium text-gray-700">
+            Arquivo CSV
+          </label>
+          <input
+            id="cadasturCsv"
+            name="cadasturCsv"
+            type="file"
+            accept=".csv,text/csv"
+            onChange={handleFileChange}
+            className="mt-1 block w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-trekko-yellow"
+            aria-describedby="cadasturCsvHelp"
+          />
+          <p id="cadasturCsvHelp" className="mt-2 text-sm text-gray-500">
+            O arquivo deve conter cabeçalho e estar separado por vírgulas.
+          </p>
+        </div>
+
+        <div className="flex items-center gap-3">
+          <button
+            type="submit"
+            className="inline-flex items-center justify-center rounded-md bg-trekko-yellow px-4 py-2 font-semibold text-black hover:brightness-95 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-trekko-yellow disabled:opacity-60"
+            disabled={status === 'uploading'}
+          >
+            {status === 'uploading' ? 'Importando...' : 'Enviar arquivo'}
+          </button>
+          {file && status === 'idle' && <span className="text-sm text-gray-600">Arquivo selecionado: {file.name}</span>}
+        </div>
+      </form>
+
+      {errorMessage && (
+        <div className="mt-6 rounded-md border border-red-200 bg-red-50 p-4 text-red-700" role="alert">
+          <p className="font-semibold">Erro</p>
+          <p>{errorMessage}</p>
+        </div>
+      )}
+
+      {summary && (
+        <div
+          className="mt-6 rounded-md border border-green-200 bg-green-50 p-4 text-green-900"
+          role={status === 'success' ? 'status' : 'alert'}
+        >
+          <p className="font-semibold mb-2">Resumo da importação</p>
+          <ul className="list-disc list-inside space-y-1 text-sm">
+            <li>
+              <strong>{summary.totalValid}</strong> registros válidos processados
+            </li>
+            <li>
+              <strong>{summary.inserted}</strong> novos guias inseridos
+            </li>
+            <li>
+              <strong>{summary.updated}</strong> guias atualizados
+            </li>
+            <li>
+              <strong>{summary.discarded}</strong> linhas descartadas
+            </li>
+          </ul>
+          {summary.errors && summary.errors.length > 0 && (
+            <details className="mt-3">
+              <summary className="cursor-pointer text-sm font-semibold text-trekko-blue">Ver detalhes de erros</summary>
+              <ul className="mt-2 space-y-1 text-sm text-gray-700">
+                {summary.errors.map((msg) => (
+                  <li key={msg}>{msg}</li>
+                ))}
+              </ul>
+            </details>
+          )}
         </div>
       )}
     </div>

--- a/pages/api/admin/cadastur/upload.ts
+++ b/pages/api/admin/cadastur/upload.ts
@@ -1,0 +1,187 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import Papa from 'papaparse'
+import prisma from '../../../../lib/prisma'
+import {
+  normalizeGuideRecord,
+  REQUIRED_CSV_COLUMNS,
+  type CadasturCsvRecord,
+  type NormalizedGuideRecord
+} from '../../../../lib/cadastur'
+
+interface ParsedMultipartFile {
+  filename: string
+  content: string
+}
+
+const readMultipartCsv = async (req: NextApiRequest): Promise<ParsedMultipartFile | null> => {
+  const contentType = req.headers['content-type'] || ''
+  if (!contentType.toLowerCase().includes('multipart/form-data')) {
+    return null
+  }
+
+  const boundaryMatch = contentType.match(/boundary=([^;]+)/i)
+  if (!boundaryMatch) {
+    return null
+  }
+  const boundary = boundaryMatch[1]
+
+  const chunks: Buffer[] = []
+  for await (const chunk of req) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk))
+  }
+
+  const buffer = Buffer.concat(chunks)
+  const rawParts = buffer
+    .toString('utf8')
+    .split(`--${boundary}`)
+    .filter((part) => part.trim() && part.trim() !== '--')
+
+  for (const rawPart of rawParts) {
+    const part = rawPart.trim()
+    const [rawHeaders, ...bodyParts] = part.split('\r\n\r\n')
+    if (!rawHeaders || bodyParts.length === 0) continue
+    const headers = rawHeaders.split('\r\n').filter(Boolean)
+    const disposition = headers.find((header) => header.toLowerCase().startsWith('content-disposition'))
+    if (!disposition || !/filename="/i.test(disposition)) continue
+
+    const filenameMatch = disposition.match(/filename="([^"]+)"/i)
+    const filename = filenameMatch?.[1] ?? 'upload.csv'
+    const body = bodyParts.join('\r\n\r\n')
+    const content = body.replace(/\r\n--$/g, '').replace(/\r\n$/g, '')
+
+    return { filename, content }
+  }
+
+  return null
+}
+
+export const config = {
+  api: {
+    bodyParser: false
+  }
+}
+
+const handler = async (req: NextApiRequest, res: NextApiResponse) => {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', ['POST'])
+    return res.status(405).json({ error: 'Method not allowed' })
+  }
+
+  try {
+    const parsedFile = await readMultipartCsv(req)
+    if (!parsedFile) {
+      return res.status(400).json({ error: 'Arquivo CSV não enviado. Use o campo "file".' })
+    }
+
+    const content = parsedFile.content
+    const parsed = Papa.parse<Record<string, string>>(content, {
+      header: true,
+      skipEmptyLines: true
+    })
+
+    if (parsed.errors.length > 0) {
+      console.error('[admin/cadastur/upload] parse errors', parsed.errors)
+      return res.status(400).json({ error: 'Erro ao ler CSV', details: parsed.errors })
+    }
+
+    const fields = parsed.meta.fields ?? []
+    const missing = REQUIRED_CSV_COLUMNS.filter((col) => !fields.includes(col))
+    if (missing.length > 0) {
+      return res.status(400).json({
+        error: 'CSV inválido',
+        details: `Colunas obrigatórias ausentes: ${missing.join(', ')}`
+      })
+    }
+
+    const normalized: NormalizedGuideRecord[] = []
+    const errors: string[] = []
+    const seenCadastur = new Set<string>()
+
+    parsed.data.forEach((row, index) => {
+      const castRow: CadasturCsvRecord = {
+        nome_completo: row['nome_completo'],
+        cadastur: row['cadastur'],
+        uf: row['uf'],
+        municipio: row['municipio'],
+        whatsapp: row['whatsapp'],
+        instagram: row['instagram'],
+        foto_url: row['foto_url'],
+        bio: row['bio']
+      }
+
+      const normalizedRow = normalizeGuideRecord(castRow)
+      if (!normalizedRow) {
+        errors.push(`Linha ${index + 2}: dados obrigatórios ausentes ou inválidos.`)
+        return
+      }
+
+      if (seenCadastur.has(normalizedRow.cadastur)) {
+        errors.push(`Linha ${index + 2}: número Cadastur duplicado no arquivo (${normalizedRow.cadastur}).`)
+        return
+      }
+      seenCadastur.add(normalizedRow.cadastur)
+      normalized.push(normalizedRow)
+    })
+
+    if (normalized.length === 0) {
+      return res.status(400).json({ error: 'Nenhum registro válido encontrado.', details: errors })
+    }
+
+    let inserted = 0
+    let updated = 0
+
+    await prisma.$transaction(async (tx) => {
+      for (const guide of normalized) {
+        const existing = await tx.cadasturGuide.findUnique({ where: { cadastur: guide.cadastur } })
+
+        await tx.cadasturGuide.upsert({
+          where: { cadastur: guide.cadastur },
+          create: {
+            cadastur: guide.cadastur,
+            nomeCompleto: guide.nome_completo,
+            uf: guide.uf,
+            municipio: guide.municipio,
+            whatsapp: guide.whatsapp,
+            instagram: guide.instagram,
+            fotoUrl: guide.foto_url,
+            bio: guide.bio
+          },
+          update: {
+            nomeCompleto: guide.nome_completo,
+            uf: guide.uf,
+            municipio: guide.municipio,
+            whatsapp: guide.whatsapp,
+            instagram: guide.instagram,
+            fotoUrl: guide.foto_url,
+            bio: guide.bio
+          }
+        })
+
+        if (existing) {
+          updated += 1
+        } else {
+          inserted += 1
+        }
+      }
+    })
+
+    console.info('[admin/cadastur/upload] import summary', {
+      inserted,
+      updated,
+      discarded: errors.length
+    })
+
+    return res.status(200).json({
+      inserted,
+      updated,
+      discarded: errors.length,
+      totalValid: normalized.length,
+      errors
+    })
+  } catch (error) {
+    console.error('[admin/cadastur/upload] error', error)
+    return res.status(500).json({ error: 'Erro interno ao importar CSV' })
+  }
+}
+
+export default handler

--- a/pages/api/guias/[cadastur].ts
+++ b/pages/api/guias/[cadastur].ts
@@ -1,0 +1,64 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import prisma from '../../../lib/prisma'
+import { checkRateLimit } from '../../../lib/rateLimit'
+
+const cacheControl = 'public, max-age=60, s-maxage=60, stale-while-revalidate=30'
+
+const handler = async (req: NextApiRequest, res: NextApiResponse) => {
+  if (req.method !== 'GET') {
+    res.setHeader('Allow', ['GET'])
+    return res.status(405).json({ error: 'Method not allowed' })
+  }
+
+  const identifier =
+    (req.headers['x-forwarded-for'] as string)?.split(',')[0]?.trim() || req.socket.remoteAddress || 'unknown'
+  const rate = checkRateLimit(identifier)
+  res.setHeader('RateLimit-Limit', rate.limit.toString())
+  res.setHeader('RateLimit-Remaining', rate.remaining.toString())
+  res.setHeader('RateLimit-Reset', rate.reset.toString())
+  if (!rate.allowed) {
+    return res.status(429).json({ error: 'Too many requests' })
+  }
+
+  const cadastur = Array.isArray(req.query.cadastur) ? req.query.cadastur[0] : req.query.cadastur
+  if (!cadastur) {
+    return res.status(400).json({ error: 'Informe o número do Cadastur' })
+  }
+
+  try {
+    const start = Date.now()
+    const guide = await prisma.cadasturGuide.findUnique({
+      where: { cadastur }
+    })
+
+    if (!guide) {
+      return res.status(404).json({ error: 'Guia não encontrado' })
+    }
+
+    res.setHeader('Cache-Control', cacheControl)
+
+    const duration = Date.now() - start
+    console.info('[api/guias/:cadastur] detail', {
+      cadastur,
+      durationMs: duration
+    })
+
+    return res.status(200).json({
+      id: guide.id,
+      cadastur: guide.cadastur,
+      nome_completo: guide.nomeCompleto,
+      uf: guide.uf,
+      municipio: guide.municipio,
+      whatsapp: guide.whatsapp,
+      instagram: guide.instagram,
+      foto_url: guide.fotoUrl,
+      bio: guide.bio,
+      expedicoes: []
+    })
+  } catch (error) {
+    console.error('[api/guias/:cadastur] error', error)
+    return res.status(500).json({ error: 'Internal server error' })
+  }
+}
+
+export default handler

--- a/pages/api/guias/filters.ts
+++ b/pages/api/guias/filters.ts
@@ -1,0 +1,57 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import prisma from '../../../lib/prisma'
+import { checkRateLimit } from '../../../lib/rateLimit'
+
+const cacheControl = 'public, max-age=60, s-maxage=60, stale-while-revalidate=30'
+
+const handler = async (req: NextApiRequest, res: NextApiResponse) => {
+  if (req.method !== 'GET') {
+    res.setHeader('Allow', ['GET'])
+    return res.status(405).json({ error: 'Method not allowed' })
+  }
+
+  const identifier =
+    (req.headers['x-forwarded-for'] as string)?.split(',')[0]?.trim() || req.socket.remoteAddress || 'unknown'
+  const rate = checkRateLimit(identifier)
+  res.setHeader('RateLimit-Limit', rate.limit.toString())
+  res.setHeader('RateLimit-Remaining', rate.remaining.toString())
+  res.setHeader('RateLimit-Reset', rate.reset.toString())
+  if (!rate.allowed) {
+    return res.status(429).json({ error: 'Too many requests' })
+  }
+
+  try {
+    const ufParam = Array.isArray(req.query.uf) ? req.query.uf[0] : req.query.uf
+
+    if (ufParam) {
+      const uf = ufParam.trim().toUpperCase()
+      if (!uf) {
+        return res.status(400).json({ error: 'UF inválida' })
+      }
+
+      const municipios = await prisma.cadasturGuide.findMany({
+        where: { uf },
+        select: { municipio: true },
+        distinct: ['municipio'],
+        orderBy: { municipio: 'asc' }
+      })
+
+      res.setHeader('Cache-Control', cacheControl)
+      return res.status(200).json({ municipios: municipios.map((m) => m.municipio) })
+    }
+
+    const ufs = await prisma.cadasturGuide.findMany({
+      select: { uf: true },
+      distinct: ['uf'],
+      orderBy: { uf: 'asc' }
+    })
+
+    res.setHeader('Cache-Control', cacheControl)
+    return res.status(200).json({ ufs: ufs.map((u) => u.uf) })
+  } catch (error) {
+    console.error('[api/guias/filters] error', error)
+    return res.status(500).json({ error: 'Internal server error' })
+  }
+}
+
+export default handler

--- a/pages/api/guias/index.ts
+++ b/pages/api/guias/index.ts
@@ -1,0 +1,81 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import prisma from '../../../lib/prisma'
+import {
+  buildGuideQueryOptions,
+  DEFAULT_PAGE_SIZE,
+  GuideQueryParams
+} from '../../../lib/cadastur'
+import { checkRateLimit } from '../../../lib/rateLimit'
+
+const cacheControl = 'public, max-age=60, s-maxage=60, stale-while-revalidate=30'
+
+const handler = async (req: NextApiRequest, res: NextApiResponse) => {
+  if (req.method !== 'GET') {
+    res.setHeader('Allow', ['GET'])
+    return res.status(405).json({ error: 'Method not allowed' })
+  }
+
+  const identifier =
+    (req.headers['x-forwarded-for'] as string)?.split(',')[0]?.trim() || req.socket.remoteAddress || 'unknown'
+  const rate = checkRateLimit(identifier)
+  res.setHeader('RateLimit-Limit', rate.limit.toString())
+  res.setHeader('RateLimit-Remaining', rate.remaining.toString())
+  res.setHeader('RateLimit-Reset', rate.reset.toString())
+  if (!rate.allowed) {
+    return res.status(429).json({ error: 'Too many requests' })
+  }
+
+  try {
+    const start = Date.now()
+    const options = buildGuideQueryOptions(req.query as GuideQueryParams)
+
+    const [items, totalItems] = await prisma.$transaction([
+      prisma.cadasturGuide.findMany({
+        where: options.where,
+        orderBy: options.orderBy,
+        skip: options.skip,
+        take: options.take
+      }),
+      prisma.cadasturGuide.count({ where: options.where })
+    ])
+
+    const totalPages = totalItems === 0 ? 0 : Math.ceil(totalItems / (options.pageSize || DEFAULT_PAGE_SIZE))
+
+    res.setHeader('Cache-Control', cacheControl)
+
+    const responseItems = items.map((guide) => ({
+      id: guide.id,
+      cadastur: guide.cadastur,
+      nome_completo: guide.nomeCompleto,
+      uf: guide.uf,
+      municipio: guide.municipio,
+      whatsapp: guide.whatsapp,
+      instagram: guide.instagram,
+      foto_url: guide.fotoUrl,
+      bio: guide.bio
+    }))
+
+    const duration = Date.now() - start
+    console.info('[api/guias] query', {
+      filters: options.where,
+      sort: options.sort,
+      page: options.page,
+      pageSize: options.pageSize,
+      totalItems,
+      durationMs: duration
+    })
+
+    return res.status(200).json({
+      items: responseItems,
+      page: options.page,
+      pageSize: options.pageSize,
+      totalItems,
+      totalPages
+    })
+  } catch (error) {
+    console.error('[api/guias] error', error)
+    return res.status(500).json({ error: 'Internal server error' })
+  }
+}
+
+export default handler

--- a/pages/guias/[cadastur].tsx
+++ b/pages/guias/[cadastur].tsx
@@ -1,0 +1,273 @@
+import Head from 'next/head'
+import Link from 'next/link'
+import { useRouter } from 'next/router'
+import React, { useEffect, useMemo, useState } from 'react'
+import type { GuideDetailResponse } from '../../types/guide'
+
+const WhatsappIcon = () => (
+  <svg viewBox="0 0 32 32" fill="currentColor" aria-hidden="true" className="h-5 w-5">
+    <path d="M16 3C9.4 3 4 8.3 4 15c0 2.7.9 5.1 2.5 7.1L5 29l7.1-1.5C13.9 28.4 15 28.6 16 28.6c6.6 0 12-5.3 12-11.9C28 8.3 22.6 3 16 3zm-.1 22.1c-.9 0-1.8-.2-2.7-.5l-.3-.1-4.2.9.9-4.1-.2-.3c-1.4-1.8-2.1-3.9-2.1-6.1 0-5.4 4.4-9.7 9.7-9.7s9.7 4.4 9.7 9.7c.1 5.4-4.3 9.7-9.8 9.7zm5.3-7.1c-.3-.2-1.8-.9-2.1-1-.3-.1-.5-.2-.7.2-.2.3-.8 1-.9 1.1-.2.2-.3.2-.6.1-.3-.2-1.2-.5-2.3-1.5-.8-.7-1.3-1.6-1.5-1.9-.2-.3 0-.5.1-.6.1-.1.3-.3.4-.5.1-.2.2-.3.3-.5.1-.2.1-.3 0-.5-.1-.2-.7-1.7-.9-2.3-.2-.6-.5-.5-.7-.5h-.6c-.2 0-.5.1-.8.3-.3.2-1.1 1-1.1 2.4s1.1 2.8 1.2 3c.2.3 2.2 3.4 5.3 4.7.7.3 1.2.5 1.6.6.7.2 1.3.2 1.8.1.6-.1 1.8-.7 2-1.4.3-.7.3-1.2.2-1.4-.1-.2-.3-.3-.6-.5z" />
+  </svg>
+)
+
+const InstagramIcon = () => (
+  <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true" className="h-5 w-5">
+    <path d="M7 2C4.243 2 2 4.243 2 7v10c0 2.757 2.243 5 5 5h10c2.757 0 5-2.243 5-5V7c0-2.757-2.243-5-5-5H7zm0 2h10c1.654 0 3 1.346 3 3v10c0 1.654-1.346 3-3 3H7c-1.654 0-3-1.346-3-3V7c0-1.654 1.346-3 3-3zm11 1a1 1 0 100 2 1 1 0 000-2zM12 7a5 5 0 100 10 5 5 0 000-10zm0 2a3 3 0 110 6 3 3 0 010-6z" />
+  </svg>
+)
+
+const initialsFromName = (name: string) => {
+  const parts = name.trim().split(/\s+/)
+  if (parts.length === 0) return '??'
+  if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase()
+  return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase()
+}
+
+const GuideProfilePage: React.FC = () => {
+  const router = useRouter()
+  const cadastur = typeof router.query.cadastur === 'string' ? router.query.cadastur : undefined
+  const [guide, setGuide] = useState<GuideDetailResponse | null>(null)
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [notFound, setNotFound] = useState(false)
+  const [imageError, setImageError] = useState(false)
+
+  useEffect(() => {
+    setImageError(false)
+  }, [guide?.foto_url])
+
+  useEffect(() => {
+    if (!cadastur) return
+    let active = true
+    const controller = new AbortController()
+
+    const fetchGuide = async () => {
+      setIsLoading(true)
+      setError(null)
+      setNotFound(false)
+      try {
+        const res = await fetch(`/api/guias/${encodeURIComponent(cadastur)}`, {
+          signal: controller.signal
+        })
+        if (res.status === 404) {
+          if (active) {
+            setGuide(null)
+            setNotFound(true)
+          }
+          return
+        }
+        if (!res.ok) {
+          throw new Error('Erro ao carregar guia')
+        }
+        const payload = (await res.json()) as GuideDetailResponse
+        if (active) {
+          setGuide(payload)
+        }
+      } catch (err) {
+        if (!controller.signal.aborted) {
+          console.error(err)
+          setError('Ocorreu um erro ao carregar o guia. Tente novamente.')
+        }
+      } finally {
+        if (active) {
+          setIsLoading(false)
+        }
+      }
+    }
+
+    fetchGuide()
+
+    return () => {
+      active = false
+      controller.abort()
+    }
+  }, [cadastur])
+
+  const whatsappUrl = useMemo(() => {
+    if (!guide?.whatsapp) return null
+    const digits = guide.whatsapp.replace(/\D+/g, '')
+    return digits ? `https://wa.me/${digits}` : null
+  }, [guide?.whatsapp])
+
+  const instagramUrl = useMemo(() => {
+    if (!guide?.instagram) return null
+    return `https://instagram.com/${guide.instagram}`
+  }, [guide?.instagram])
+
+  const title = guide ? `${guide.nome_completo} | Guias CADASTUR | Trekko` : 'Guia CADASTUR | Trekko'
+  const description = guide
+    ? `Guia ${guide.nome_completo} credenciado CADASTUR em ${guide.municipio}/${guide.uf}. Contato, bio e expedições no Trekko.`
+    : 'Conheça guias CADASTUR no Trekko.'
+
+  const jsonLd = guide
+    ? {
+        '@context': 'https://schema.org',
+        '@type': 'Person',
+        name: guide.nome_completo,
+        identifier: guide.cadastur,
+        address: {
+          '@type': 'PostalAddress',
+          addressLocality: guide.municipio,
+          addressRegion: guide.uf,
+          addressCountry: 'BR'
+        },
+        image: guide.foto_url ?? undefined,
+        url: `${process.env.NEXT_PUBLIC_SITE_URL ?? ''}/guias/${encodeURIComponent(guide.cadastur)}`
+      }
+    : null
+
+  return (
+    <>
+      <Head>
+        <title>{title}</title>
+        <meta name="description" content={description} />
+        {jsonLd && <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }} />}
+      </Head>
+      <main className="min-h-screen bg-gray-50 py-12">
+        <div className="mx-auto max-w-5xl px-4">
+          <Link href="/guias" className="text-sm font-semibold text-trekko-blue hover:text-trekko-green">
+            ← Voltar para lista de guias
+          </Link>
+
+          {isLoading && (
+            <section className="mt-8 animate-pulse rounded-xl bg-white p-6 shadow">
+              <div className="flex flex-col gap-6 md:flex-row">
+                <div className="h-60 w-full rounded-xl bg-gray-200 md:w-60" />
+                <div className="flex-1 space-y-4">
+                  <div className="h-8 w-1/2 rounded bg-gray-200" />
+                  <div className="h-4 w-1/3 rounded bg-gray-200" />
+                  <div className="h-4 w-2/3 rounded bg-gray-200" />
+                  <div className="h-4 w-full rounded bg-gray-200" />
+                  <div className="h-4 w-3/4 rounded bg-gray-200" />
+                </div>
+              </div>
+            </section>
+          )}
+
+          {error && !isLoading && (
+            <div className="mt-8 rounded-md border border-red-200 bg-red-50 p-6 text-red-700" role="alert">
+              {error}
+            </div>
+          )}
+
+          {!isLoading && !error && notFound && (
+            <div className="mt-8 rounded-md border border-gray-200 bg-white p-8 text-center text-gray-600">
+              Guia não encontrado.
+            </div>
+          )}
+
+          {!isLoading && !error && guide && (
+            <>
+              <section className="mt-8 grid gap-6 rounded-xl border border-gray-200 bg-white p-6 shadow md:grid-cols-[240px,1fr]">
+                <div className="overflow-hidden rounded-xl bg-trekko-sand">
+                  {guide.foto_url && !imageError ? (
+                    <img
+                      src={guide.foto_url}
+                      alt={`Foto de ${guide.nome_completo}`}
+                      className="h-full w-full object-cover"
+                      onError={() => setImageError(true)}
+                    />
+                  ) : (
+                    <div className="flex h-60 items-center justify-center bg-gradient-to-br from-trekko-sand to-trekko-yellow text-4xl font-semibold text-trekko-blue">
+                      {initialsFromName(guide.nome_completo)}
+                    </div>
+                  )}
+                </div>
+
+                <div className="flex flex-col gap-4">
+                  <div>
+                    <h1 className="text-3xl font-bold text-trekko-blue">{guide.nome_completo}</h1>
+                    <p className="mt-1 text-gray-600">
+                      Cadastur {guide.cadastur} · {guide.municipio}/{guide.uf}
+                    </p>
+                  </div>
+
+                  <div className="flex flex-wrap items-center gap-3">
+                    {whatsappUrl && (
+                      <a
+                        href={whatsappUrl}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="inline-flex items-center gap-2 rounded-full bg-green-500 px-4 py-2 text-sm font-semibold text-white hover:bg-green-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-green-500"
+                        aria-label="Conversar no WhatsApp"
+                      >
+                        <WhatsappIcon /> WhatsApp
+                      </a>
+                    )}
+                    {instagramUrl && (
+                      <a
+                        href={instagramUrl}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="inline-flex items-center gap-2 rounded-full bg-gradient-to-r from-purple-500 to-pink-500 px-4 py-2 text-sm font-semibold text-white hover:brightness-110 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-pink-400"
+                        aria-label="Ver Instagram"
+                      >
+                        <InstagramIcon /> Instagram
+                      </a>
+                    )}
+                  </div>
+
+                  {guide.bio && (
+                    <div>
+                      <h2 className="text-xl font-semibold text-trekko-blue">Sobre</h2>
+                      <p className="mt-2 whitespace-pre-line text-gray-700">{guide.bio}</p>
+                    </div>
+                  )}
+                </div>
+              </section>
+
+              <section className="mt-10 rounded-xl border border-gray-200 bg-white p-6 shadow">
+                <div className="flex items-center justify-between gap-4">
+                  <h2 className="text-2xl font-semibold text-trekko-blue">Expedições</h2>
+                  <Link
+                    href={`/expedicoes?guia=${encodeURIComponent(guide.cadastur)}`}
+                    className="text-sm font-semibold text-trekko-blue hover:text-trekko-green"
+                  >
+                    Ver expedições do Trekko
+                  </Link>
+                </div>
+
+                {guide.expedicoes.length === 0 && (
+                  <p className="mt-4 text-gray-600">Nenhuma expedição disponível no momento.</p>
+                )}
+
+                {guide.expedicoes.length > 0 && (
+                  <div className="mt-6 grid gap-4 sm:grid-cols-2">
+                    {guide.expedicoes.map((expedicao) => (
+                      <article key={expedicao.id} className="rounded-lg border border-gray-200 p-4 shadow-sm">
+                        <h3 className="text-lg font-semibold text-trekko-blue">{expedicao.trilha_nome}</h3>
+                        <p className="mt-1 text-sm text-gray-600">
+                          {expedicao.cidade}/{expedicao.uf} ·{' '}
+                          {new Date(expedicao.data_inicio).toLocaleDateString('pt-BR')} -{' '}
+                          {new Date(expedicao.data_fim).toLocaleDateString('pt-BR')}
+                        </p>
+                        <p className="mt-2 text-sm text-gray-700">
+                          {expedicao.preco_por_pessoa.toLocaleString('pt-BR', {
+                            style: 'currency',
+                            currency: 'BRL'
+                          })}{' '}
+                          por pessoa
+                        </p>
+                        <p className="mt-1 text-xs text-gray-500">
+                          {expedicao.vagas_disponiveis} vagas disponíveis de {expedicao.vagas_max}
+                        </p>
+                        <Link
+                          href={`/expedicoes?guia=${encodeURIComponent(guide.cadastur)}&expedicao=${expedicao.id}`}
+                          className="mt-3 inline-flex items-center rounded-full bg-trekko-yellow px-4 py-2 text-sm font-semibold text-black hover:brightness-95"
+                        >
+                          Reservar
+                        </Link>
+                      </article>
+                    ))}
+                  </div>
+                )}
+              </section>
+            </>
+          )}
+        </div>
+      </main>
+    </>
+  )
+}
+
+export default GuideProfilePage

--- a/pages/guias/index.tsx
+++ b/pages/guias/index.tsx
@@ -1,0 +1,302 @@
+import Head from 'next/head'
+import { useRouter } from 'next/router'
+import React, { useEffect, useMemo, useState } from 'react'
+import GuideCard from '../../components/guides/GuideCard'
+import GuideFilters, { type GuideFilterState } from '../../components/guides/GuideFilters'
+import Pagination from '../../components/guides/Pagination'
+import type { GuideListResponse } from '../../types/guide'
+
+const DEFAULT_PAGE_SIZE = Number(process.env.NEXT_PUBLIC_GUIDES_PAGE_SIZE ?? 30) || 30
+
+const GuidesPage: React.FC = () => {
+  const router = useRouter()
+  const [filters, setFilters] = useState<GuideFilterState>({
+    uf: '',
+    municipio: '',
+    nome: '',
+    cadastur: '',
+    sort: 'nome_asc'
+  })
+  const [currentPage, setCurrentPage] = useState(1)
+  const [listData, setListData] = useState<GuideListResponse | null>(null)
+  const [isLoadingList, setIsLoadingList] = useState(false)
+  const [listError, setListError] = useState<string | null>(null)
+  const [ufOptions, setUfOptions] = useState<string[]>([])
+  const [municipioOptions, setMunicipioOptions] = useState<string[]>([])
+  const [isLoadingMunicipios, setIsLoadingMunicipios] = useState(false)
+  const [reloadToken, setReloadToken] = useState(0)
+
+  useEffect(() => {
+    if (!router.isReady) return
+
+    const queryValue = (value: string | string[] | undefined) => {
+      if (!value) return ''
+      return Array.isArray(value) ? value[0] : value
+    }
+
+    const nextFilters: GuideFilterState = {
+      uf: queryValue(router.query.uf).toUpperCase(),
+      municipio: queryValue(router.query.municipio),
+      nome: queryValue(router.query.nome),
+      cadastur: queryValue(router.query.cadastur),
+      sort: queryValue(router.query.sort) || 'nome_asc'
+    }
+
+    setFilters((prev) => {
+      if (JSON.stringify(prev) === JSON.stringify(nextFilters)) {
+        return prev
+      }
+      return nextFilters
+    })
+
+    const pageNumber = Number(queryValue(router.query.page) || '1')
+    setCurrentPage(Number.isNaN(pageNumber) || pageNumber < 1 ? 1 : pageNumber)
+  }, [router.isReady, router.query])
+
+  const apiQuery = useMemo(() => {
+    if (!router.isReady) return null
+    const params = new URLSearchParams()
+
+    const queryValue = (key: string) => {
+      const value = router.query[key]
+      if (!value) return ''
+      return Array.isArray(value) ? value[0] : value
+    }
+
+    const uf = queryValue('uf')
+    const municipio = queryValue('municipio')
+    const nome = queryValue('nome')
+    const cadastur = queryValue('cadastur')
+    const sort = queryValue('sort') || 'nome_asc'
+    const pageParam = Number(queryValue('page') || '1')
+    const pageSizeParam = Number(queryValue('pageSize') || DEFAULT_PAGE_SIZE)
+
+    if (uf) params.set('uf', uf)
+    if (municipio) params.set('municipio', municipio)
+    if (nome) params.set('nome', nome)
+    if (cadastur) params.set('cadastur', cadastur)
+    if (sort) params.set('sort', sort)
+
+    params.set('page', (Number.isNaN(pageParam) || pageParam < 1 ? 1 : pageParam).toString())
+    params.set('pageSize', (Number.isNaN(pageSizeParam) || pageSizeParam < 1 ? DEFAULT_PAGE_SIZE : Math.min(pageSizeParam, DEFAULT_PAGE_SIZE)).toString())
+
+    return params.toString()
+  }, [router.isReady, router.query])
+
+  useEffect(() => {
+    if (!router.isReady) return
+    let active = true
+    const controller = new AbortController()
+
+    const fetchGuides = async () => {
+      if (!apiQuery) return
+      setIsLoadingList(true)
+      setListError(null)
+      try {
+        const res = await fetch(`/api/guias?${apiQuery}`, { signal: controller.signal })
+        if (!res.ok) {
+          throw new Error('Erro ao carregar guias')
+        }
+        const payload = (await res.json()) as GuideListResponse
+        if (active) {
+          setListData(payload)
+        }
+      } catch (err) {
+        if (!controller.signal.aborted) {
+          console.error(err)
+          setListError('Não foi possível carregar os guias.')
+        }
+      } finally {
+        if (active) {
+          setIsLoadingList(false)
+        }
+      }
+    }
+
+    fetchGuides()
+
+    return () => {
+      active = false
+      controller.abort()
+    }
+  }, [router.isReady, apiQuery, reloadToken])
+
+  useEffect(() => {
+    if (!router.isReady) return
+    let active = true
+    const loadUfs = async () => {
+      try {
+        const res = await fetch('/api/guias/filters')
+        if (!res.ok) throw new Error('Erro ao carregar UFs')
+        const payload = (await res.json()) as { ufs: string[] }
+        if (active) setUfOptions(payload.ufs)
+      } catch (err) {
+        console.error(err)
+      }
+    }
+    loadUfs()
+    return () => {
+      active = false
+    }
+  }, [router.isReady])
+
+  useEffect(() => {
+    if (!filters.uf) {
+      setMunicipioOptions([])
+      setIsLoadingMunicipios(false)
+      return
+    }
+    let active = true
+    const controller = new AbortController()
+    const loadMunicipios = async () => {
+      setIsLoadingMunicipios(true)
+      try {
+        const res = await fetch(`/api/guias/filters?uf=${encodeURIComponent(filters.uf)}`, {
+          signal: controller.signal
+        })
+        if (!res.ok) throw new Error('Erro ao carregar municípios')
+        const payload = (await res.json()) as { municipios: string[] }
+        if (active) setMunicipioOptions(payload.municipios)
+      } catch (err) {
+        if (!controller.signal.aborted) {
+          console.error(err)
+        }
+      } finally {
+        if (active) setIsLoadingMunicipios(false)
+      }
+    }
+    loadMunicipios()
+    return () => {
+      active = false
+      controller.abort()
+    }
+  }, [filters.uf])
+
+  const handleFilterChange = (field: keyof GuideFilterState, value: string) => {
+    setFilters((prev) => {
+      const next = { ...prev, [field]: value }
+      if (field === 'uf') {
+        next.municipio = ''
+      }
+      return next
+    })
+  }
+
+  const applyFilters = () => {
+    const query: Record<string, string> = {}
+    if (filters.uf) query.uf = filters.uf
+    if (filters.municipio) query.municipio = filters.municipio
+    if (filters.nome) query.nome = filters.nome
+    if (filters.cadastur) query.cadastur = filters.cadastur
+    if (filters.sort && filters.sort !== 'nome_asc') query.sort = filters.sort
+    query.page = '1'
+    query.pageSize = DEFAULT_PAGE_SIZE.toString()
+
+    router.push({ pathname: '/guias', query }, undefined, { shallow: true })
+  }
+
+  const resetFilters = () => {
+    setFilters({ uf: '', municipio: '', nome: '', cadastur: '', sort: 'nome_asc' })
+    router.push({ pathname: '/guias' }, undefined, { shallow: true })
+  }
+
+  const handlePageChange = (page: number) => {
+    const query = { ...router.query, page: page.toString() }
+    if (!query.pageSize) {
+      query.pageSize = DEFAULT_PAGE_SIZE.toString()
+    }
+    router.push({ pathname: '/guias', query }, undefined, { shallow: true })
+  }
+
+  const totalItems = listData?.totalItems ?? 0
+  const totalPages = listData?.totalPages ?? 0
+  const itemsCount = listData?.items.length ?? 0
+  const isLoading = isLoadingList
+  const error = listError
+  const retry = () => setReloadToken((prev) => prev + 1)
+
+  return (
+    <>
+      <Head>
+        <title>Guias CADASTUR | Trekko</title>
+        <meta
+          name="description"
+          content="Conheça guias credenciados no CADASTUR em todo o Brasil. Filtre por UF, município ou nome e encontre seu guia Trekko."
+        />
+      </Head>
+      <main className="min-h-screen bg-gray-50 py-10">
+        <div className="mx-auto max-w-6xl px-4">
+          <header className="mb-10 text-center">
+            <h1 className="text-3xl font-bold text-trekko-blue">Guias CADASTUR</h1>
+            <p className="mt-2 text-gray-600">
+              Exibindo {itemsCount} de {totalItems} guias
+            </p>
+          </header>
+
+          <GuideFilters
+            filters={filters}
+            onChange={handleFilterChange}
+            onSubmit={applyFilters}
+            onReset={resetFilters}
+            ufOptions={ufOptions}
+            municipioOptions={municipioOptions}
+            isLoadingMunicipios={isLoadingMunicipios}
+          />
+
+          {isLoading && (
+            <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3" role="status" aria-live="polite">
+              {Array.from({ length: 6 }).map((_, index) => (
+                <div key={index} className="h-80 animate-pulse rounded-xl bg-white shadow-inner">
+                  <div className="h-40 rounded-t-xl bg-gray-200" />
+                  <div className="space-y-3 p-4">
+                    <div className="h-6 rounded bg-gray-200" />
+                    <div className="h-4 rounded bg-gray-200" />
+                    <div className="h-4 rounded bg-gray-200" />
+                    <div className="h-4 rounded bg-gray-200" />
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+
+          {error && !isLoading && (
+            <div className="rounded-md border border-red-200 bg-red-50 p-6 text-center text-red-700" role="alert">
+              <p className="font-semibold">Não foi possível carregar os guias.</p>
+              <p className="mt-2 text-sm">Tente novamente.</p>
+              <button
+                type="button"
+                onClick={retry}
+                className="mt-4 inline-flex items-center rounded-md bg-trekko-blue px-4 py-2 text-sm font-semibold text-white hover:bg-trekko-green focus:bg-trekko-green focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-trekko-yellow"
+              >
+                Tentar novamente
+              </button>
+            </div>
+          )}
+
+          {!isLoading && !error && listData && listData.items.length === 0 && (
+            <div className="rounded-md border border-gray-200 bg-white p-8 text-center text-gray-600">
+              Nenhum guia encontrado. Ajuste os filtros.
+            </div>
+          )}
+
+          {!isLoading && !error && listData && listData.items.length > 0 && (
+            <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+              {listData.items.map((guide) => (
+                <GuideCard key={guide.id} guide={guide} />
+              ))}
+            </div>
+          )}
+
+          <Pagination
+            currentPage={currentPage}
+            totalPages={totalPages}
+            onPageChange={handlePageChange}
+            disabled={isLoading}
+          />
+        </div>
+      </main>
+    </>
+  )
+}
+
+export default GuidesPage

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -26,25 +26,26 @@ enum UserRole {
 }
 
 model Guide {
-  id          Int                 @id @default(autoincrement())
+  id          Int               @id @default(autoincrement())
   name        String
   email       String
   phone       String?
-  cadastur    String              @unique
+  cadastur    String            @unique
   uf          String?
   city        String?
   validity    DateTime?
   specialties String?
-  createdAt   DateTime            @default(now())
-  updatedAt   DateTime            @updatedAt
+  createdAt   DateTime          @default(now())
+  updatedAt   DateTime          @updatedAt
   imports     GuideImportItem[]
+  User        User[]
 }
 
 model GuideImport {
-  id        Int           @id @default(autoincrement())
-  status    ImportStatus  @default(PENDING)
-  createdAt DateTime      @default(now())
-  updatedAt DateTime      @updatedAt
+  id        Int               @id @default(autoincrement())
+  status    ImportStatus      @default(PENDING)
+  createdAt DateTime          @default(now())
+  updatedAt DateTime          @updatedAt
   items     GuideImportItem[]
 }
 
@@ -79,4 +80,23 @@ enum ImportItemStatus {
   VALID
   ERROR
   IMPORTED
+}
+
+model CadasturGuide {
+  id           Int      @id @default(autoincrement())
+  cadastur     String   @unique @db.VarChar(32)
+  nomeCompleto String   @map("nome_completo") @db.VarChar(180)
+  uf           String   @db.Char(2)
+  municipio    String   @db.VarChar(120)
+  whatsapp     String?  @db.VarChar(32)
+  instagram    String?  @db.VarChar(120)
+  fotoUrl      String?  @map("foto_url")
+  bio          String?
+  createdAt    DateTime @default(now()) @map("created_at")
+  updatedAt    DateTime @default(now()) @updatedAt @map("updated_at")
+
+  @@index([uf], map: "idx_guias_uf")
+  @@index([municipio], map: "idx_guias_municipio")
+  @@index([nomeCompleto], map: "idx_guias_nome")
+  @@map("guias")
 }

--- a/tests/cadastur.test.ts
+++ b/tests/cadastur.test.ts
@@ -1,0 +1,72 @@
+import assert from 'node:assert/strict'
+import {
+  buildGuideQueryOptions,
+  normalizeGuideRecord,
+  sanitizeInstagramHandle,
+  sanitizeWhatsapp,
+  toTitleCase
+} from '../lib/cadastur'
+
+const runCadasturTests = () => {
+  assert.equal(toTitleCase('ana maria da silva'), 'Ana Maria da Silva')
+  assert.equal(toTitleCase('  JOÃO  DOS SANTOS '), 'João dos Santos')
+  assert.equal(toTitleCase('maria-aparecida de souza'), 'Maria-Aparecida de Souza')
+
+  assert.equal(sanitizeWhatsapp('(11) 99999-8888'), '+5511999998888')
+  assert.equal(sanitizeWhatsapp('5511987654321'), '+5511987654321')
+  assert.equal(sanitizeWhatsapp('123'), null)
+
+  assert.equal(sanitizeInstagramHandle('https://instagram.com/trekko.br/'), 'trekko.br')
+  assert.equal(sanitizeInstagramHandle('@trekko'), 'trekko')
+
+  const normalized = normalizeGuideRecord({
+    nome_completo: 'ana maria',
+    cadastur: '123',
+    uf: 'sp',
+    municipio: 'sao paulo',
+    whatsapp: '(11) 99999-9999',
+    instagram: 'https://instagram.com/ana',
+    foto_url: 'https://example.com/foto.jpg',
+    bio: 'bio'
+  })
+
+  assert.deepEqual(normalized, {
+    nome_completo: 'Ana Maria',
+    cadastur: '123',
+    uf: 'SP',
+    municipio: 'Sao Paulo',
+    whatsapp: '+5511999999999',
+    instagram: 'ana',
+    foto_url: 'https://example.com/foto.jpg',
+    bio: 'bio'
+  })
+
+  const invalid = normalizeGuideRecord({
+    nome_completo: '',
+    cadastur: '',
+    uf: 'sp',
+    municipio: 'sao paulo',
+    whatsapp: undefined,
+    instagram: undefined,
+    foto_url: undefined,
+    bio: undefined
+  })
+  assert.equal(invalid, null)
+
+  const options = buildGuideQueryOptions({ nome: 'ana', page: '2' })
+  assert.deepEqual(options.where, {
+    nomeCompleto: { contains: 'ana', mode: 'insensitive' }
+  })
+  assert.equal(options.page, 2)
+  assert.ok(options.pageSize > 0)
+  assert.equal(options.skip, options.pageSize)
+
+  const clamped = buildGuideQueryOptions({ page: '-5', pageSize: '999', uf: 'sp' })
+  assert.equal(clamped.page, 1)
+  assert.ok(clamped.pageSize <= 50)
+  assert.deepEqual(clamped.where, { uf: 'SP' })
+}
+
+runCadasturTests()
+
+console.log('cadastur tests passed')

--- a/tsconfig.tests.json
+++ b/tsconfig.tests.json
@@ -1,0 +1,14 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "outDir": "./tests/dist",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "target": "ES2019",
+    "esModuleInterop": true,
+    "isolatedModules": false
+  },
+  "include": ["lib/**/*.ts", "tests/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/types/guide.ts
+++ b/types/guide.ts
@@ -1,0 +1,35 @@
+export interface Guide {
+  id: number
+  cadastur: string
+  nome_completo: string
+  uf: string
+  municipio: string
+  whatsapp: string | null
+  instagram: string | null
+  foto_url: string | null
+  bio: string | null
+}
+
+export interface GuideListResponse {
+  items: Guide[]
+  page: number
+  pageSize: number
+  totalItems: number
+  totalPages: number
+}
+
+export interface ExpeditionSummary {
+  id: number
+  trilha_nome: string
+  cidade: string
+  uf: string
+  data_inicio: string
+  data_fim: string
+  preco_por_pessoa: number
+  vagas_max: number
+  vagas_disponiveis: number
+}
+
+export interface GuideDetailResponse extends Guide {
+  expedicoes: ExpeditionSummary[]
+}


### PR DESCRIPTION
## Summary
- add Prisma model and CSV upload API for Cadastur guide ingestion with normalization, upsert, and duplicate checks
- expose guide listing, filter metadata, and detail endpoints with rate limiting, caching headers, and pagination metadata
- build guide directory and profile pages with reusable UI components, error/loading states, and social contact links

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68dacd8858a083248f12f5d186ddd011