### PR TITLE
Add ETag support to Cadastur guides API responses

### DIFF
--- a/pages/api/guias/[cadastur].ts
+++ b/pages/api/guias/[cadastur].ts
@@ -1,6 +1,10 @@
 import type { NextApiRequest, NextApiResponse } from 'next'
 import prisma from '../../../lib/prisma'
 import { checkRateLimit } from '../../../lib/rateLimit'
+import { createHash } from 'crypto'
+
+const buildEtag = (payload: unknown) =>
+  `W/"${createHash('sha256').update(JSON.stringify(payload)).digest('base64')}"`
 
 const cacheControl = 'public, max-age=60, s-maxage=60, stale-while-revalidate=30'
 
@@ -35,15 +39,7 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
       return res.status(404).json({ error: 'Guia não encontrado' })
     }
 
-    res.setHeader('Cache-Control', cacheControl)
-
-    const duration = Date.now() - start
-    console.info('[api/guias/:cadastur] detail', {
-      cadastur,
-      durationMs: duration
-    })
-
-    return res.status(200).json({
+    const responsePayload = {
       id: guide.id,
       cadastur: guide.cadastur,
       nome_completo: guide.nomeCompleto,
@@ -54,7 +50,25 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
       foto_url: guide.fotoUrl,
       bio: guide.bio,
       expedicoes: []
+    }
+
+    const etag = buildEtag(responsePayload)
+    if (req.headers['if-none-match'] === etag) {
+      res.setHeader('Cache-Control', cacheControl)
+      res.setHeader('ETag', etag)
+      return res.status(304).end()
+    }
+
+    res.setHeader('Cache-Control', cacheControl)
+    res.setHeader('ETag', etag)
+
+    const duration = Date.now() - start
+    console.info('[api/guias/:cadastur] detail', {
+      cadastur,
+      durationMs: duration
     })
+
+    return res.status(200).json(responsePayload)
   } catch (error) {
     console.error('[api/guias/:cadastur] error', error)
     return res.status(500).json({ error: 'Internal server error' })

--- a/pages/api/guias/index.ts
+++ b/pages/api/guias/index.ts
@@ -6,6 +6,10 @@ import {
   GuideQueryParams
 } from '../../../lib/cadastur'
 import { checkRateLimit } from '../../../lib/rateLimit'
+import { createHash } from 'crypto'
+
+const buildEtag = (payload: unknown) =>
+  `W/"${createHash('sha256').update(JSON.stringify(payload)).digest('base64')}"`
 
 const cacheControl = 'public, max-age=60, s-maxage=60, stale-while-revalidate=30'
 
@@ -41,8 +45,6 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
 
     const totalPages = totalItems === 0 ? 0 : Math.ceil(totalItems / (options.pageSize || DEFAULT_PAGE_SIZE))
 
-    res.setHeader('Cache-Control', cacheControl)
-
     const responseItems = items.map((guide) => ({
       id: guide.id,
       cadastur: guide.cadastur,
@@ -55,6 +57,24 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
       bio: guide.bio
     }))
 
+    const responsePayload = {
+      items: responseItems,
+      page: options.page,
+      pageSize: options.pageSize,
+      totalItems,
+      totalPages
+    }
+
+    const etag = buildEtag(responsePayload)
+    if (req.headers['if-none-match'] === etag) {
+      res.setHeader('Cache-Control', cacheControl)
+      res.setHeader('ETag', etag)
+      return res.status(304).end()
+    }
+
+    res.setHeader('Cache-Control', cacheControl)
+    res.setHeader('ETag', etag)
+
     const duration = Date.now() - start
     console.info('[api/guias] query', {
       filters: options.where,
@@ -65,13 +85,7 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
       durationMs: duration
     })
 
-    return res.status(200).json({
-      items: responseItems,
-      page: options.page,
-      pageSize: options.pageSize,
-      totalItems,
-      totalPages
-    })
+    return res.status(200).json(responsePayload)
   } catch (error) {
     console.error('[api/guias] error', error)
     return res.status(500).json({ error: 'Internal server error' })


### PR DESCRIPTION
## Summary
- add weak ETag generation to the Cadastur guides list and detail endpoints
- respond with 304 Not Modified when client-supplied ETag matches cached payload
- ensure Cache-Control headers are still emitted alongside the new validator

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dae2f1d19c8324afc5e34db72f869d