### PR TITLE
Integrate guides pages with CADASTUR CSV dataset

### DIFF
--- a/cadastur-utils.js
+++ b/cadastur-utils.js
@@ -1,0 +1,258 @@
+(function (global) {
+  const DEFAULT_URL = 'data/CADASTUR.csv';
+  const HEADER_MAP = {
+    'atividade turistica': 'atividade_turistica',
+    'uf': 'uf',
+    'estado': 'uf',
+    'municipio': 'municipio',
+    'município': 'municipio',
+    'nome completo': 'nome_completo',
+    'telefone comercial': 'telefone_comercial',
+    'telefone': 'telefone_comercial',
+    'e-mail comercial': 'email_comercial',
+    'email comercial': 'email_comercial',
+    'website': 'website',
+    'numero do certificado': 'numero_cadastur',
+    'número do certificado': 'numero_cadastur',
+    'numero do cadastur': 'numero_cadastur',
+    'validade do certificado': 'validade_certificado',
+    'idiomas': 'idiomas',
+    'municipio de atuacao': 'municipio_de_atuacao',
+    'município de atuação': 'municipio_de_atuacao',
+    'categoria(s)': 'categorias',
+    'categorias': 'categorias',
+    'segmento(s)': 'segmentos',
+    'segmentos': 'segmentos',
+    'guia motorista': 'guia_motorista'
+  };
+
+  const TITLE_EXCEPTIONS = new Set(['da', 'de', 'do', 'das', 'dos', 'e']);
+
+  const normalizeHeaderKey = (header) => {
+    if (!header) return '';
+    return header
+      .replace(/\ufeff/g, '')
+      .trim()
+      .toLowerCase()
+      .normalize('NFD')
+      .replace(/[\u0300-\u036f]/g, '')
+      .replace(/\s+/g, ' ');
+  };
+
+  const toTitleCase = (value) => {
+    if (!value) return '';
+    const trimmed = value.toString().trim();
+    if (!trimmed) return '';
+    return trimmed
+      .toLocaleLowerCase('pt-BR')
+      .split(/\s+/)
+      .map((segment, index) =>
+        segment
+          .split('-')
+          .map((piece, pieceIndex) => {
+            const lower = piece.trim();
+            if (!lower) return '';
+            const shouldCapitalize = index === 0 && pieceIndex === 0 ? true : !TITLE_EXCEPTIONS.has(lower);
+            return shouldCapitalize
+              ? lower.charAt(0).toLocaleUpperCase('pt-BR') + lower.slice(1)
+              : lower;
+          })
+          .join('-')
+      )
+      .join(' ');
+  };
+
+  const splitList = (value) => {
+    if (!value) return [];
+    return value
+      .toString()
+      .split('|')
+      .map((part) => toTitleCase(part))
+      .filter(Boolean);
+  };
+
+  const splitCsvLine = (line, delimiter = ';') => {
+    const result = [];
+    let current = '';
+    let inQuotes = false;
+    for (let i = 0; i < line.length; i += 1) {
+      const char = line[i];
+      if (char === '"') {
+        if (inQuotes && line[i + 1] === '"') {
+          current += '"';
+          i += 1;
+        } else {
+          inQuotes = !inQuotes;
+        }
+        continue;
+      }
+      if (char === delimiter && !inQuotes) {
+        result.push(current);
+        current = '';
+      } else {
+        current += char;
+      }
+    }
+    result.push(current);
+    return result;
+  };
+
+  const buildContacts = (telefone, email, website) => {
+    const contacts = [];
+    if (telefone) contacts.push(`Whatsapp:${telefone}`);
+    if (email) contacts.push(`Email:${email}`);
+    if (website) contacts.push(`Website:${website}`);
+    return contacts.join('|');
+  };
+
+  const formatBio = ({ idiomasLista, categoriasLista, segmentosLista, atuacaoLista }) => {
+    const parts = [];
+    if (categoriasLista.length) {
+      parts.push(`Categorias: ${categoriasLista.join(', ')}`);
+    }
+    if (segmentosLista.length) {
+      parts.push(`Segmentos: ${segmentosLista.join(', ')}`);
+    }
+    if (idiomasLista.length) {
+      parts.push(`Idiomas: ${idiomasLista.join(', ')}`);
+    }
+    if (atuacaoLista.length) {
+      const destaque = atuacaoLista.slice(0, 3);
+      parts.push(`Atua em: ${destaque.join(', ')}`);
+    }
+    return parts.join(' • ');
+  };
+
+  const parseBoolean = (value) => {
+    if (value == null) return false;
+    const normalized = value.toString().trim().toLowerCase();
+    if (!normalized) return false;
+    return ['1', 'sim', 's', 'true'].includes(normalized);
+  };
+
+  const parseCadasturCsv = (text) => {
+    if (!text) return [];
+    const normalized = text.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+    const lines = normalized.split('\n');
+    if (!lines.length) return [];
+    const headerLine = lines.shift();
+    if (!headerLine) return [];
+    const headersRaw = splitCsvLine(headerLine, ';');
+    const headers = headersRaw.map((header) => {
+      const key = normalizeHeaderKey(header);
+      if (!key) return null;
+      if (HEADER_MAP[key]) return HEADER_MAP[key];
+      return key.replace(/[^a-z0-9]+/g, '_');
+    });
+
+    const rows = [];
+    for (const line of lines) {
+      if (!line || !line.trim()) continue;
+      const values = splitCsvLine(line, ';');
+      const entry = {};
+      for (let i = 0; i < headers.length; i += 1) {
+        const key = headers[i];
+        if (!key) continue;
+        const rawValue = values[i] != null ? values[i].replace(/\ufeff/g, '').trim() : '';
+        entry[key] = rawValue;
+      }
+      if (Object.values(entry).every((value) => !value)) continue;
+      rows.push(entry);
+    }
+    return rows;
+  };
+
+  const normalizeRow = (entry) => {
+    const nomeOriginal = entry.nome_completo || entry.nome;
+    const municipioOriginal = entry.municipio || entry['município'];
+    const ufOriginal = entry.uf || entry.estado;
+    const cadasturOriginal = entry.numero_cadastur || entry.numero || entry['numero do certificado'] || entry['número_do_certificado'];
+
+    const nome = toTitleCase(nomeOriginal);
+    const municipio = toTitleCase(municipioOriginal);
+    const uf = (ufOriginal || '').toString().trim().toUpperCase();
+    const cadastur = (cadasturOriginal || '').toString().trim();
+
+    if (!nome || !municipio || uf.length !== 2 || !cadastur) {
+      return null;
+    }
+
+    const telefone = (entry.telefone_comercial || '').trim();
+    const email = (entry.email_comercial || '').trim();
+    const website = (entry.website || '').trim();
+
+    const idiomasLista = splitList(entry.idiomas);
+    const categoriasLista = splitList(entry.categorias);
+    const segmentosLista = splitList(entry.segmentos);
+    const atuacaoLista = splitList(entry.municipio_de_atuacao);
+
+    const bio = formatBio({ idiomasLista, categoriasLista, segmentosLista, atuacaoLista });
+
+    return {
+      ...entry,
+      id: cadastur,
+      cadastur,
+      numero_cadastur: cadastur,
+      nome,
+      nome_completo: nome,
+      municipio,
+      uf,
+      telefone_comercial: telefone,
+      email_comercial: email,
+      website,
+      idiomas_lista: idiomasLista,
+      categorias_lista: categoriasLista,
+      segmentos_lista: segmentosLista,
+      municipio_de_atuacao_lista: atuacaoLista,
+      guia_motorista: parseBoolean(entry.guia_motorista),
+      contatos: buildContacts(telefone, email, website),
+      bio,
+      foto_url: entry.foto_url || entry.foto || '',
+      validade_certificado: entry.validade_certificado || entry['validade_do_certificado'] || ''
+    };
+  };
+
+  let cachedPromise = null;
+  let cachedData = null;
+  let cachedUrl = DEFAULT_URL;
+
+  const fetchCadasturData = (url = DEFAULT_URL) => {
+    const targetUrl = url || DEFAULT_URL;
+    if (cachedData && cachedUrl === targetUrl) {
+      return Promise.resolve(cachedData);
+    }
+    if (cachedPromise && cachedUrl === targetUrl) {
+      return cachedPromise;
+    }
+
+    cachedUrl = targetUrl;
+    cachedPromise = fetch(targetUrl, { cache: 'no-store' })
+      .then((response) => {
+        if (!response.ok) {
+          throw new Error(`HTTP ${response.status}`);
+        }
+        return response.text();
+      })
+      .then((text) => parseCadasturCsv(text))
+      .then((rows) => rows.map(normalizeRow).filter(Boolean))
+      .then((normalized) => {
+        cachedData = normalized;
+        return normalized;
+      })
+      .finally(() => {
+        cachedPromise = null;
+      });
+
+    return cachedPromise;
+  };
+
+  global.CadasturUtils = {
+    DEFAULT_URL,
+    fetchCadasturData,
+    toTitleCase,
+    splitList,
+    splitCsvLine,
+    parseCadasturCsv,
+    normalizeRow
+  };
+})(window);

--- a/guia.html
+++ b/guia.html
@@ -82,6 +82,7 @@
     </footer>
     <script src="auth.js"></script>
     <script src="scripts.js"></script>
+    <script src="cadastur-utils.js"></script>
 
     <!-- Fonte oficial (CSV preferido + fallback JS) -->
     <script>

--- a/guias.html
+++ b/guias.html
@@ -421,8 +421,10 @@
   </footer>
   <script src="auth.js"></script>
   <script src="scripts.js"></script>
+  <script src="cadastur-utils.js"></script>
   <script>
     const API_BASE = '/api/guias';
+    const CADASTUR_CSV_URL = 'data/CADASTUR.csv';
     const FALLBACK_DATA_URL = 'data/guides.json';
     const pageSize = 30;
     const placeholders = Array.from({ length: 6 });
@@ -430,6 +432,7 @@
     const collator = new Intl.Collator('pt-BR', { sensitivity: 'base', usage: 'sort' });
     let fallbackDataset = null;
     let triedFallback = false;
+    let triedCadasturCsv = false;
 
     const refs = {
       form: document.getElementById('filtersForm'),
@@ -541,7 +544,31 @@
     }
 
     async function ensureFallbackData() {
-      if (fallbackDataset || triedFallback) {
+      if (fallbackDataset) {
+        return fallbackDataset;
+      }
+
+      if (!triedCadasturCsv && window.CadasturUtils) {
+        triedCadasturCsv = true;
+        try {
+          const rawCsv = await window.CadasturUtils.fetchCadasturData(CADASTUR_CSV_URL);
+          if (Array.isArray(rawCsv)) {
+            const mapped = rawCsv.map(normalizeFallbackGuide).filter(Boolean);
+            if (mapped.length) {
+              fallbackDataset = mapped;
+              return fallbackDataset;
+            }
+          }
+        } catch (csvError) {
+          console.warn('Não foi possível carregar CADASTUR.csv', csvError);
+        }
+      }
+
+      if (fallbackDataset) {
+        return fallbackDataset;
+      }
+
+      if (triedFallback) {
         return fallbackDataset;
       }
 

--- a/guide_profile.js
+++ b/guide_profile.js
@@ -4,6 +4,8 @@
   const container = document.getElementById('guide-detail');
   if (!container) return;
 
+  const CADASTUR_CSV_URL = 'data/CADASTUR.csv';
+
   const slugify = (s) =>
     (s || '')
       .normalize('NFD').replace(/[\u0300-\u036f]/g, '')
@@ -50,23 +52,20 @@
   };
 
   async function loadData() {
-    if (window.__USE_CSV__) {
+    if (window.__USE_CSV__ && window.CadasturUtils) {
       try {
-        const resp = await fetch('data/cadastur.csv', { cache: 'no-store' });
-        if (resp.ok) {
-          const text = await resp.text();
-          const [header, ...lines] = text.trim().split(/\r?\n/);
-          const cols = header.split(',').map(h=>h.trim());
-          return lines.map(line => {
-            const parts = line.split(',');
-            const obj = {};
-            cols.forEach((c,i)=>obj[c]=parts[i]);
-            return obj;
-          }).map(norm);
+        const rawCsv = await window.CadasturUtils.fetchCadasturData(CADASTUR_CSV_URL);
+        if (Array.isArray(rawCsv) && rawCsv.length) {
+          return rawCsv.map(norm);
         }
-      } catch(_) {}
+      } catch (error) {
+        console.warn('Não foi possível carregar CADASTUR.csv', error);
+      }
     }
-    return (Array.isArray(window.cadasturData) ? window.cadasturData.map(norm) : []);
+    if (Array.isArray(window.cadasturData)) {
+      return window.cadasturData.map(norm);
+    }
+    return [];
   }
 
   function render(guide) {

--- a/guides_list.js
+++ b/guides_list.js
@@ -72,24 +72,16 @@
 
   // ---- Carregar dados: CSV (preferência) ou JS (fallback) ----
   async function loadData() {
-    // Tentar CSV?
-    if (window.__USE_CSV__) {
+    // Preferir o CSV oficial quando disponível
+    if (window.__USE_CSV__ && window.CadasturUtils) {
       try {
-        const resp = await fetch('data/cadastur.csv', { cache: 'no-store' });
-        if (resp.ok) {
-          const text = await resp.text();
-          const [header, ...lines] = text.trim().split(/\r?\n/);
-          const cols = header.split(',').map(h=>h.trim());
-          const rows = lines.map(line => {
-            // parser leve (atenção: CSV simples — se seu CSV tem vírgulas entre aspas, troque por PapaParse)
-            const parts = line.split(','); 
-            const obj = {};
-            cols.forEach((c,i)=>obj[c]=parts[i]);
-            return obj;
-          });
-          return rows.map(normalize);
+        const raw = await window.CadasturUtils.fetchCadasturData('data/CADASTUR.csv');
+        if (Array.isArray(raw) && raw.length) {
+          return raw.map(normalize);
         }
-      } catch (_) { /* ignora e cai no fallback */ }
+      } catch (_) {
+        // ignora e cai no fallback em caso de erro
+      }
     }
     // Fallback: usar dataset JS embutido (window.cadasturData)
     if (Array.isArray(window.cadasturData)) return window.cadasturData.map(normalize);


### PR DESCRIPTION
## Summary
- add a reusable CADASTUR CSV parsing utility to expose normalized guide data in the browser
- update the guides listing and profile pages to load the official CADASTUR.csv dataset and only fall back to seeded data when needed
- point legacy scripts at the shared loader so searches and detail views stay in sync with the CSV data

## Testing
- no automated tests were run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68daf18d3b7c8324a61acc31e72ec9ee