### PR TITLE
feat: revamp trail detail flow with guide and expedition links

### DIFF
--- a/data/guides.js
+++ b/data/guides.js
@@ -17,10 +17,12 @@ window.guidesData = [
     email_comercial: "joao@example.com",
     website: "www.joaosantos.com.br",
     número_do_certificado: "MG123456",
+    cadastur: "MG123456",
     validade_do_certificado: "2026-12-31 23:59:59",
+    trilhas_guiadas: ["pico-bandeira", "marins-itaguare", "pico-cristal"],
     descricao: "Especialista em trilhas e atrações históricas em Minas Gerais, combinando conhecimento local com atenção especial à segurança dos visitantes.",
-    image: "images/guia1.png"
-    ,rating: 4.9
+    image: "images/guia1.png",
+    rating: 4.9
   },
   {
     id: 2,
@@ -37,10 +39,12 @@ window.guidesData = [
     email_comercial: "ana@example.com",
     website: "www.anapereira.guia.br",
     número_do_certificado: "RJ987654",
+    cadastur: "RJ987654",
     validade_do_certificado: "2025-11-30 23:59:59",
+    trilhas_guiadas: ["pedra-bonita"],
     descricao: "Guia apaixonada por história e cultura carioca, conduzindo grupos por museus, igrejas e pontos turísticos icônicos.",
-    image: "images/guia2.png"
-    ,rating: 4.8
+    image: "images/guia2.png",
+    rating: 4.8
   },
   {
     id: 3,
@@ -57,10 +61,12 @@ window.guidesData = [
     email_comercial: "carlos@example.com",
     website: "www.carlossilva.tur",
     número_do_certificado: "SP345678",
+    cadastur: "SP345678",
     validade_do_certificado: "2027-06-15 23:59:59",
+    trilhas_guiadas: ["cachoeira-tabuleiro", "marins-itaguare"],
     descricao: "Com veículo próprio, Carlos combina aventuras ao ar livre com experiências gastronômicas e recomendações de restaurantes locais.",
-    image: "images/guia3.png"
-    ,rating: 4.7
+    image: "images/guia3.png",
+    rating: 4.7
   },
   {
     id: 4,
@@ -77,10 +83,12 @@ window.guidesData = [
     email_comercial: "mariana@example.com",
     website: "www.marianaoliveira.guia",
     número_do_certificado: "PR654321",
+    cadastur: "PR654321",
     validade_do_certificado: "2026-03-20 23:59:59",
+    trilhas_guiadas: ["pico-neblina"],
     descricao: "Experiência de mais de 10 anos guiando turistas em parques nacionais e pontos históricos do Paraná, com foco em ecoturismo sustentável.",
-    image: "images/guia1.png"
-    ,rating: 4.6
+    image: "images/guia1.png",
+    rating: 4.6
   },
   {
     id: 5,
@@ -97,9 +105,11 @@ window.guidesData = [
     email_comercial: "pedro@example.com",
     website: "www.pedrogomes.guia.br",
     número_do_certificado: "CE789012",
+    cadastur: "CE789012",
     validade_do_certificado: "2025-08-10 23:59:59",
+    trilhas_guiadas: ["pico-neblina"],
     descricao: "Nativo do litoral cearense, Pedro oferece passeios em praias paradisíacas e aventuras de buggy nas dunas.",
-    image: "images/guia2.png"
-    ,rating: 4.5
+    image: "images/guia2.png",
+    rating: 4.5
   }
 ];

--- a/data/trails.js
+++ b/data/trails.js
@@ -20,6 +20,8 @@ window.trailsData = [
     entryFee: 0,
     image: 'images/pico-bandeira.jpg',
     gallery: ['images/pico-bandeira.jpg'],
+    guideIds: ['1', '3'],
+    guideCadastur: ['MG123456', 'SP345678'],
     longDescription:
       'Uma das travessias mais emblemáticas do país, a subida ao Pico da Bandeira conduz o trekker por florestas de araucárias, campos de altitude e cumes graníticos que parecem tocar o céu. A jornada exige planejamento e preparo físico, mas recompensa com nasceres do sol inesquecíveis e o encontro com a cultura local de Alto Caparaó.',
     description:
@@ -77,6 +79,8 @@ window.trailsData = [
     entryFee: 0,
     image: 'images/pedra-bonita.jpg',
     gallery: ['images/pedra-bonita.jpg'],
+    guideIds: ['2'],
+    guideCadastur: ['RJ987654'],
     longDescription:
       'Ideal para quem busca uma experiência inesquecível sem grandes dificuldades técnicas, a trilha da Pedra Bonita percorre a Mata Atlântica carioca com trechos sombreados e mirantes naturais. No topo, o visual de 360° abraça o litoral do Rio e a Pedra da Gávea, tornando-se perfeito para um nascer do sol em alto estilo.',
     description:
@@ -134,6 +138,8 @@ window.trailsData = [
     entryFee: 30,
     image: 'images/cachoeira-tabuleiro.jpg',
     gallery: ['images/cachoeira-tabuleiro.jpg'],
+    guideIds: ['3'],
+    guideCadastur: ['SP345678'],
     longDescription:
       'Caminhada clássica do Espinhaço, a trilha do Tabuleiro combina travessia por lajedos, rios cristalinos e a visão hipnótica da maior queda d’água de Minas Gerais. O percurso é moderado e alterna subidas com trechos planos, perfeito para quem quer uma aventura completa em um único dia.',
     description:
@@ -191,6 +197,8 @@ window.trailsData = [
     entryFee: 0,
     image: 'images/marins-itaguare.jpg',
     gallery: ['images/marins-itaguare.jpg'],
+    guideIds: ['1', '3'],
+    guideCadastur: ['MG123456', 'SP345678'],
     longDescription:
       'Uma travessia lendária entre Minas Gerais e São Paulo, a Marins-Itaguaré exige navegação precisa, travessia de lajes inclinadas e acampamentos selvagens. Ideal para montanhistas experientes que buscam desafios técnicos, paisagens de altitude e noites estreladas a mais de 2.000 metros.',
     description:
@@ -248,6 +256,8 @@ window.trailsData = [
     entryFee: 0,
     image: 'images/pico-cristal.jpg',
     gallery: ['images/pico-cristal.jpg'],
+    guideIds: ['1'],
+    guideCadastur: ['MG123456'],
     longDescription:
       'O Pico do Cristal é a segunda montanha mais alta do Parque Nacional do Caparaó. A trilha segue pelo Vale Encantado e exige atenção nas lajes inclinadas próximas ao cume. Ideal para trekkers que já conhecem o Pico da Bandeira e buscam uma alternativa menos movimentada.',
     description:
@@ -305,6 +315,8 @@ window.trailsData = [
     entryFee: 100,
     image: 'images/pico-neblina.jpg',
     gallery: ['images/pico-neblina.jpg'],
+    guideIds: ['4', '5'],
+    guideCadastur: ['PR654321', 'CE789012'],
     longDescription:
       'Localizado no coração da Amazônia e dentro de território Yanomami, o Pico da Neblina é a montanha mais alta do Brasil e um símbolo de respeito à floresta. A expedição exige autorização oficial, guia especializado e espírito de equipe, recompensando com uma imersão profunda na cultura indígena e na biodiversidade da região.',
     description:

--- a/guias.html
+++ b/guias.html
@@ -120,6 +120,35 @@
       gap: 1.5rem;
       grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
     }
+    .guides-context {
+      margin: 1.5rem 0 0;
+    }
+    .guides-context[hidden] {
+      display: none;
+    }
+    .guides-context .context-card {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.75rem;
+      align-items: center;
+      background: rgba(26, 77, 46, 0.08);
+      color: var(--color-primary);
+      border-radius: 14px;
+      padding: 1rem 1.25rem;
+      font-weight: 600;
+    }
+    .guides-context .context-card button {
+      background: none;
+      border: none;
+      color: var(--color-secondary);
+      font-weight: 600;
+      cursor: pointer;
+      text-decoration: underline;
+    }
+    .guides-context .context-card button:hover,
+    .guides-context .context-card button:focus-visible {
+      color: #d98f42;
+    }
     .guide-card {
       background: #fff;
       border-radius: 18px;
@@ -380,6 +409,8 @@
           </div>
         </div>
 
+        <div id="trailContext" class="guides-context" hidden></div>
+
         <div id="guidesState" aria-live="polite"></div>
         <div class="guides-grid" id="guidesGrid" aria-live="polite" aria-busy="true"></div>
         <nav class="pagination" id="pagination" aria-label="Paginação de guias"></nav>
@@ -419,6 +450,7 @@
     </div>
     <div class="footer-bottom">© 2025 Trekko Brasil. Todos os direitos reservados.</div>
   </footer>
+  <script src="data/trails.js"></script>
   <script src="auth.js"></script>
   <script src="scripts.js"></script>
   <script src="cadastur-utils.js"></script>
@@ -445,6 +477,7 @@
       grid: document.getElementById('guidesGrid'),
       pagination: document.getElementById('pagination'),
       state: document.getElementById('guidesState'),
+      context: document.getElementById('trailContext'),
       clear: document.getElementById('clearFilters'),
       reload: document.getElementById('reloadButton')
     };
@@ -458,11 +491,42 @@
         municipio: '',
         nome: '',
         cadastur: '',
-        sort: 'nome_asc'
+        sort: 'nome_asc',
+        trail: ''
       },
       loading: false,
       error: ''
     };
+
+    if (typeof computeSlugs === 'function') {
+      computeSlugs();
+    }
+
+    const trailMetadataMap = (() => {
+      const map = new Map();
+      if (Array.isArray(window.trailsData)) {
+        window.trailsData.forEach((trail) => {
+          const cadList = Array.isArray(trail.guideCadastur)
+            ? trail.guideCadastur.map((value) => String(value).toUpperCase()).filter(Boolean)
+            : [];
+          const meta = {
+            id: trail.id || '',
+            slug: trail.slug || '',
+            name: trail.name || '',
+            cadastur: cadList
+          };
+          [meta.id, meta.slug]
+            .filter(Boolean)
+            .forEach((key) => map.set(String(key).toLowerCase(), meta));
+        });
+      }
+      return map;
+    })();
+
+    function getTrailMeta(value) {
+      if (!value) return null;
+      return trailMetadataMap.get(String(value).toLowerCase()) || null;
+    }
 
     function toTitleCase(value) {
       if (!value) return '';
@@ -620,6 +684,16 @@
         filtered = filtered.filter((guide) => guide.cadastur.toLocaleLowerCase('pt-BR') === cadFilter);
       }
 
+      if (state.filters.trail) {
+        const meta = getTrailMeta(state.filters.trail);
+        if (meta && Array.isArray(meta.cadastur) && meta.cadastur.length) {
+          const cadSet = new Set(meta.cadastur.map((value) => value.toLowerCase()));
+          filtered = filtered.filter((guide) => guide.cadastur && cadSet.has(guide.cadastur.toLowerCase()));
+        } else {
+          filtered = [];
+        }
+      }
+
       const sortKey = state.filters.sort || 'nome_asc';
       const sorters = {
         nome_asc: (a, b) => collator.compare(a.nome_completo, b.nome_completo),
@@ -676,6 +750,7 @@
       state.filters.nome = params.get('nome') || '';
       state.filters.cadastur = params.get('cadastur') || '';
       state.filters.sort = params.get('sort') || 'nome_asc';
+      state.filters.trail = params.get('trail') || '';
     }
 
     function syncForm() {
@@ -692,10 +767,38 @@
       if (state.filters.nome) params.set('nome', state.filters.nome);
       if (state.filters.cadastur) params.set('cadastur', state.filters.cadastur);
       if (state.filters.sort && state.filters.sort !== 'nome_asc') params.set('sort', state.filters.sort);
+      if (state.filters.trail) params.set('trail', state.filters.trail);
       if (state.page > 1) params.set('page', String(state.page));
       const search = params.toString();
       const newUrl = `${window.location.pathname}${search ? `?${search}` : ''}`;
       window.history.replaceState({}, '', newUrl);
+    }
+
+    function renderTrailContext() {
+      if (!refs.context) return;
+      if (!state.filters.trail) {
+        refs.context.innerHTML = '';
+        refs.context.hidden = true;
+        return;
+      }
+      const meta = getTrailMeta(state.filters.trail);
+      const trailName = meta?.name || 'esta trilha';
+      refs.context.hidden = false;
+      refs.context.innerHTML = `
+        <div class="context-card">
+          <span>Filtrando por guias que atuam na trilha <strong>${trailName}</strong></span>
+          <button type="button" id="clearTrailFilter">Remover filtro</button>
+        </div>
+      `;
+      const clearTrail = document.getElementById('clearTrailFilter');
+      if (clearTrail) {
+        clearTrail.addEventListener('click', () => {
+          state.filters.trail = '';
+          updateURL();
+          renderTrailContext();
+          fetchGuides();
+        });
+      }
     }
 
     function showSkeleton() {
@@ -720,9 +823,15 @@
     function renderGuides(items) {
       refs.grid.setAttribute('aria-busy', 'false');
       refs.grid.innerHTML = '';
+      renderTrailContext();
 
       if (!items.length) {
-        refs.state.innerHTML = '<div class="guides-empty" role="status"><h3>Nenhum guia encontrado</h3><p>Ajuste os filtros ou tente outra combinação para localizar guias credenciados.</p></div>';
+        const meta = state.filters.trail ? getTrailMeta(state.filters.trail) : null;
+        if (meta) {
+          refs.state.innerHTML = `<div class="guides-empty" role="status"><h3>Nenhum guia encontrado</h3><p>Ainda não temos guias cadastrados que confirmaram atuação na trilha ${meta.name || 'selecionada'}.</p></div>`;
+        } else {
+          refs.state.innerHTML = '<div class="guides-empty" role="status"><h3>Nenhum guia encontrado</h3><p>Ajuste os filtros ou tente outra combinação para localizar guias credenciados.</p></div>';
+        }
         refs.state.setAttribute('role', 'status');
         refs.pagination.innerHTML = '';
         refs.counters.textContent = 'Nenhum guia para os filtros selecionados.';
@@ -880,6 +989,7 @@
       if (state.filters.municipio) params.set('municipio', state.filters.municipio);
       if (state.filters.nome) params.set('nome', state.filters.nome);
       if (state.filters.cadastur) params.set('cadastur', state.filters.cadastur);
+      if (state.filters.trail) params.set('trail', state.filters.trail);
 
       try {
         const response = await fetch(`${API_BASE}?${params.toString()}`, {
@@ -891,9 +1001,22 @@
           throw new Error('Não foi possível carregar os guias agora.');
         }
         const data = await response.json();
-        state.totalItems = data.totalItems || 0;
-        state.totalPages = Math.max(data.totalPages || 1, 1);
-        renderGuides(Array.isArray(data.items) ? data.items : []);
+        let items = Array.isArray(data.items) ? data.items : [];
+        if (state.filters.trail) {
+          const meta = getTrailMeta(state.filters.trail);
+          if (meta && Array.isArray(meta.cadastur) && meta.cadastur.length) {
+            const cadSet = new Set(meta.cadastur.map((value) => value.toLowerCase()));
+            items = items.filter((guide) => guide.cadastur && cadSet.has(guide.cadastur.toLowerCase()));
+          } else {
+            items = [];
+          }
+          state.totalItems = items.length;
+          state.totalPages = Math.max(1, Math.ceil(items.length / pageSize));
+        } else {
+          state.totalItems = data.totalItems || 0;
+          state.totalPages = Math.max(data.totalPages || 1, 1);
+        }
+        renderGuides(items);
       } catch (error) {
         console.error(error);
         const servedFromFallback = await tryFallbackGuides();
@@ -901,6 +1024,7 @@
           state.error = error.message || 'Erro inesperado.';
           refs.grid.setAttribute('aria-busy', 'false');
           refs.grid.innerHTML = '';
+          renderTrailContext();
           refs.counters.textContent = 'Não foi possível carregar os guias.';
           refs.state.innerHTML = `<div class="guides-error" role="alert"><h3>Erro ao carregar guias</h3><p>${state.error}</p><button class="btn btn-outline" type="button" id="retryButton">Tentar novamente</button></div>`;
           refs.state.setAttribute('role', 'alert');
@@ -936,6 +1060,7 @@
       state.filters.nome = '';
       state.filters.cadastur = '';
       state.filters.sort = 'nome_asc';
+      state.filters.trail = '';
       state.page = 1;
       refs.uf.value = '';
       refs.nome.value = '';
@@ -943,6 +1068,7 @@
       refs.sort.value = 'nome_asc';
       fetchMunicipios('', { preserveSelection: false });
       updateURL();
+      renderTrailContext();
       fetchGuides();
     });
 
@@ -968,6 +1094,7 @@
     document.addEventListener('DOMContentLoaded', async () => {
       parseQuery();
       syncForm();
+      renderTrailContext();
       await fetchUFs();
       if (state.filters.uf) {
         await fetchMunicipios(state.filters.uf, { preserveSelection: true });

--- a/scripts.js
+++ b/scripts.js
@@ -507,6 +507,7 @@ function initHomePage() {
 function initExpeditionsPage() {
   const container = document.getElementById('expeditionsContainer');
   if (!container) return;
+  computeSlugs();
   const title = document.querySelector('main h1');
   // Define filters
   const searchInput = document.getElementById('expSearchFilter');
@@ -516,6 +517,15 @@ function initExpeditionsPage() {
   const dateFilter = document.getElementById('expDateFilter');
   const clearBtn = document.getElementById('clearExpFilters');
   let list = Array.isArray(window.expeditionsData) ? [...window.expeditionsData] : [];
+  const params = new URLSearchParams(window.location.search);
+  const trailParam = params.get('trail');
+  let preselectedTrailId = '';
+  if (trailParam && Array.isArray(window.trailsData)) {
+    const matchedTrail = window.trailsData.find(t => t.slug === trailParam || t.id === trailParam);
+    if (matchedTrail) {
+      preselectedTrailId = matchedTrail.id;
+    }
+  }
   function applyFilters() {
     let results = [...list];
     const q = searchInput.value.trim().toLowerCase();
@@ -585,6 +595,9 @@ function initExpeditionsPage() {
       opt.textContent = t.name;
       trailFilter.appendChild(opt);
     });
+    if (preselectedTrailId) {
+      trailFilter.value = preselectedTrailId;
+    }
   }
   // Populate state options
   if (stateFilter) {
@@ -604,11 +617,20 @@ function initExpeditionsPage() {
       trailFilter.value = '';
       levelFilter.value = '';
       dateFilter.value = '';
+      const currentParams = new URLSearchParams(window.location.search);
+      currentParams.delete('trail');
+      const search = currentParams.toString();
+      const newUrl = `${window.location.pathname}${search ? `?${search}` : ''}`;
+      window.history.replaceState({}, '', newUrl);
       renderExpeditions(list);
     });
   }
   // Initial render
-  renderExpeditions(list);
+  if (preselectedTrailId) {
+    applyFilters();
+  } else {
+    renderExpeditions(list);
+  }
   // Handle click on details
   container.addEventListener('click', (e) => {
     const btn = e.target.closest('button[data-exp-id]');
@@ -764,6 +786,8 @@ function initTrailPage() {
     : [trail.image];
   const heroPrimaryLink = `guias.html?trail=${encodeURIComponent(trail.slug || trail.id || '')}`;
   const heroSecondaryLink = `expedicoes.html?trail=${encodeURIComponent(trail.slug || trail.id || '')}`;
+  const heroPrimaryLabel = 'Encontre guias que guiam esta trilha';
+  const heroSecondaryLabel = 'Faça parte de expedições';
   const locationSegments = [];
   if (trail.park) locationSegments.push(trail.park);
   const cityState = [trail.city, trail.state].filter(Boolean).join(' / ');
@@ -981,31 +1005,136 @@ function initTrailPage() {
     `
     : '';
 
-  const relatedGuides = Array.isArray(window.guidesData)
-    ? window.guidesData.filter(g => {
-        const matchState = g.uf && trail.state && trail.state.includes(g.uf);
-        const matchCity = g.municipio && trail.city && slugify(g.municipio) === slugify(trail.city);
+  const toSetOfStrings = (value) => {
+    if (!Array.isArray(value)) return new Set();
+    return new Set(value.map(item => String(item)).filter(Boolean));
+  };
+  const explicitGuideIds = toSetOfStrings(trail.guideIds);
+  const explicitCadastur = new Set(
+    Array.isArray(trail.guideCadastur)
+      ? trail.guideCadastur.map(item => String(item).toUpperCase()).filter(Boolean)
+      : []
+  );
+  const trailIdentifiers = new Set(
+    [trail.id, trail.slug]
+      .filter(Boolean)
+      .map(identifier => String(identifier).toLowerCase())
+  );
+  const guideMap = new Map();
+  const registerGuide = (rawGuide) => {
+    if (!rawGuide) return;
+    const cad = rawGuide.cadastur || rawGuide.numero_do_certificado || rawGuide.numero_cadastur || rawGuide.numero || '';
+    const displayGuide = {
+      id: rawGuide.id || cad || rawGuide.slug || '',
+      name: rawGuide.name || rawGuide.nome_completo || rawGuide.nome || 'Guia credenciado',
+      uf: rawGuide.uf || rawGuide.estado || '',
+      municipio: rawGuide.municipio || rawGuide['município'] || rawGuide.city || '',
+      rating: rawGuide.rating,
+      slug: rawGuide.slug,
+      cadastur: cad ? String(cad) : ''
+    };
+    const key = displayGuide.slug || displayGuide.cadastur || displayGuide.id;
+    if (!key || guideMap.has(key)) return;
+    guideMap.set(key, displayGuide);
+  };
+
+  const guideMatchesTrail = (guidedValue) => {
+    if (!guidedValue) return false;
+    if (Array.isArray(guidedValue)) {
+      return guidedValue.some(item => trailIdentifiers.has(String(item).toLowerCase()));
+    }
+    if (typeof guidedValue === 'string') {
+      return guidedValue
+        .split(/[,|]/)
+        .map(part => part.trim().toLowerCase())
+        .some(part => trailIdentifiers.has(part));
+    }
+    return false;
+  };
+
+  if (Array.isArray(window.guidesData)) {
+    window.guidesData.forEach(rawGuide => {
+      const guideId = rawGuide.id != null ? String(rawGuide.id) : null;
+      const cadValue = rawGuide.cadastur || rawGuide.numero_do_certificado || rawGuide.numero_cadastur || null;
+      const cadUpper = cadValue ? String(cadValue).toUpperCase() : null;
+      const guidedSet = rawGuide.trilhas_guiadas || rawGuide.trailsGuided || rawGuide.trilhas || rawGuide.trails;
+      const matchesTrail = guideMatchesTrail(guidedSet);
+      if (
+        (guideId && explicitGuideIds.has(guideId)) ||
+        (cadUpper && explicitCadastur.has(cadUpper)) ||
+        matchesTrail
+      ) {
+        registerGuide({ ...rawGuide, cadastur: cadValue || rawGuide.cadastur });
+      }
+    });
+  }
+
+  if (explicitCadastur.size && Array.isArray(window.cadasturData)) {
+    window.cadasturData.forEach(entry => {
+      const cad = entry.numero_cadastur || entry.numero || entry.id || '';
+      if (cad && explicitCadastur.has(String(cad).toUpperCase())) {
+        const normalised = normalizeCadasturGuide(entry);
+        registerGuide({ ...normalised, cadastur: normalised.cadastur || cad });
+      }
+    });
+  }
+
+  let relatedGuides = Array.from(guideMap.values());
+
+  if (!relatedGuides.length && Array.isArray(window.guidesData)) {
+    relatedGuides = window.guidesData
+      .filter(g => {
+        const ufValue = g.uf || '';
+        const cityValue = g.municipio || g['município'] || g.city || '';
+        const matchState = ufValue && trail.state && trail.state.toLowerCase().includes(ufValue.toString().toLowerCase());
+        const matchCity = cityValue && trail.city && slugify(cityValue) === slugify(trail.city);
         return matchState || matchCity;
       })
-    : [];
+      .map(rawGuide => ({
+        id: rawGuide.id || rawGuide.slug || '',
+        name: rawGuide.name || rawGuide.nome_completo || rawGuide.nome || 'Guia credenciado',
+        uf: rawGuide.uf || rawGuide.estado || '',
+        municipio: rawGuide.municipio || rawGuide['município'] || rawGuide.city || '',
+        rating: rawGuide.rating,
+        slug: rawGuide.slug,
+        cadastur: rawGuide.cadastur || rawGuide.numero_do_certificado || rawGuide.numero_cadastur || ''
+      }));
+  }
 
   const guidesSection = relatedGuides.length
     ? `
       <section class="trail-section">
         <h2 class="section-title">Guias que atuam aqui</h2>
         <div class="trail-guides">
-          ${relatedGuides.map(guide => `
-            <article class="guide-card-modern">
-              <div class="guide-card-modern__name">${guide.name}</div>
-              <div class="guide-card-modern__meta">${guide.uf || ''} · ${guide.municipio || guide.city || ''}</div>
-              <div class="guide-card-modern__meta">⭐ ${guide.rating || '5.0'}</div>
-              <a class="btn cta-secondary" href="guia.html?slug=${guide.slug}">Ver perfil</a>
-            </article>
-          `).join('')}
+          ${relatedGuides.map(guide => {
+            const profileUrl = guide.slug
+              ? `guia.html?slug=${encodeURIComponent(guide.slug)}`
+              : (guide.cadastur ? `guia.html?cadastur=${encodeURIComponent(guide.cadastur)}` : 'guia.html');
+            const ratingDisplay = typeof guide.rating === 'number' ? guide.rating : (guide.rating || '5.0');
+            return `
+              <article class="guide-card-modern">
+                <div class="guide-card-modern__name">${guide.name}</div>
+                <div class="guide-card-modern__meta">${guide.uf || ''} · ${guide.municipio || guide.city || ''}</div>
+                <div class="guide-card-modern__meta">⭐ ${ratingDisplay}</div>
+                <a class="btn cta-secondary" href="${profileUrl}">Ver perfil</a>
+              </article>
+            `;
+          }).join('')}
+        </div>
+        <div class="trail-guides__actions">
+          <a class="btn btn-primary" href="${heroPrimaryLink}">${heroPrimaryLabel}</a>
         </div>
       </section>
     `
-    : '';
+    : `
+      <section class="trail-section">
+        <h2 class="section-title">Guias que atuam aqui</h2>
+        <p class="trail-muted">Ainda não temos guias confirmados para esta trilha.</p>
+        <div class="trail-guides__actions">
+          <a class="btn btn-primary" href="${heroPrimaryLink}">${heroPrimaryLabel}</a>
+        </div>
+      </section>
+    `;
 
   const heroSlides = gallery
     .map((image, index) => `
@@ -1033,8 +1162,8 @@ function initTrailPage() {
           <span class="difficulty-badge ${difficultyClass}">${difficultyLabel}</span>
         </div>
         <div class="hero-cta">
-          <a href="${heroPrimaryLink}" class="btn btn-primary" data-hero-primary>Reservar Guia</a>
-          <a href="${heroSecondaryLink}" class="btn btn-secondary">Organizar Expedição</a>
+          <a href="${heroPrimaryLink}" class="btn btn-primary" data-hero-primary>${heroPrimaryLabel}</a>
+          <a href="${heroSecondaryLink}" class="btn btn-secondary">${heroSecondaryLabel}</a>
         </div>
       </div>
     </section>
@@ -1087,8 +1216,11 @@ function initTrailPage() {
   const finalCtaSection = `
     <section class="trail-section" id="trailFinalCta">
       <div class="trail-final-cta">
-        <h3>Pronto para explorar a ${trail.name}? Reserve com um guia certificado CADASTUR.</h3>
-        <a href="${heroPrimaryLink}" class="btn">Ver Guias Disponíveis</a>
+        <h3>Pronto para explorar a ${trail.name}?</h3>
+        <div class="trail-final-cta__actions">
+          <a href="${heroPrimaryLink}" class="btn">${heroPrimaryLabel}</a>
+          <a href="${heroSecondaryLink}" class="btn btn-secondary">${heroSecondaryLabel}</a>
+        </div>
       </div>
     </section>
   `;
@@ -1157,8 +1289,8 @@ function initTrailPage() {
   const floatingCTA = document.getElementById('trailFloatingCTA');
   if (floatingCTA) {
     floatingCTA.innerHTML = `
-      <span>Pronto para explorar ${trail.name}?</span>
-      <button type="button">Ver guias disponíveis</button>
+      <span>Guias certificados para ${trail.name}</span>
+      <button type="button">${heroPrimaryLabel}</button>
     `;
     const updateFloating = () => {
       if (window.innerWidth <= 768) {
@@ -1519,6 +1651,7 @@ function initBlogPostPage() {
 
   /* Trilhas page logic */
   if (document.getElementById('trailsContainer')) {
+    computeSlugs();
     // Dados de trilhas carregados a partir do dataset global (window.trailsData).
     const trailsData = Array.isArray(window.trailsData)
       ? window.trailsData.map(t => ({
@@ -1536,7 +1669,8 @@ function initBlogPostPage() {
           entryFee: typeof t.entryFee === 'number' ? t.entryFee : (t.entryFee || 0),
           image: t.image,
           description: t.description,
-          rating: t.rating
+          rating: t.rating,
+          slug: t.slug || t.id
         }))
       : [];
 
@@ -1559,7 +1693,7 @@ function initBlogPostPage() {
           <p class="card-description">${trail.description.substring(0, 120)}...</p>
           <div class="card-rating" style="font-size:0.85rem;color:var(--color-secondary);margin-top:0.25rem;"><i class="fas fa-star"></i> ${trail.rating}</div>
           <div class="card-actions">
-            <button class="btn btn-secondary" data-id="${trail.id}">Detalhes</button>
+            <a class="btn btn-secondary" href="trilha.html?slug=${encodeURIComponent(trail.slug || trail.id)}">Ver detalhes</a>
           </div>
         </div>
       `;
@@ -1637,50 +1771,6 @@ function initBlogPostPage() {
     // Render initial list
     applyTrailFilters();
 
-    // Trail details modal
-    const detailsModal = document.getElementById('trailDetailsModal');
-    const detailsContent = document.getElementById('trailDetailsContent');
-    const detailsClose = document.getElementById('trailDetailsClose');
-    function openDetails(id) {
-      const trail = trailsData.find(t => t.id === id);
-      if (!trail) return;
-      if (detailsContent) {
-        const diffLabel = trail.difficulty ? trail.difficulty.charAt(0).toUpperCase() + trail.difficulty.slice(1) : '';
-        detailsContent.innerHTML = `
-          <h2 style="margin-bottom:1rem;font-family:'Sora',sans-serif;">${trail.name}</h2>
-          <img src="${trail.image}" alt="${trail.name}" style="width:100%;border-radius:8px;margin-bottom:1rem;" />
-          <p style="margin-bottom:0.5rem;"><strong>Estado:</strong> ${trail.state}</p>
-          ${trail.city ? `<p style="margin-bottom:0.5rem;"><strong>Cidade:</strong> ${trail.city}</p>` : ''}
-          <p style="margin-bottom:0.5rem;"><strong>Dificuldade:</strong> ${diffLabel}</p>
-          <p style="margin-bottom:0.5rem;"><strong>Distância:</strong> ${trail.distance} km</p>
-          ${trail.elevationGain ? `<p style="margin-bottom:0.5rem;"><strong>Altimetria:</strong> ${trail.elevationGain} m</p>` : ''}
-          ${trail.duration ? `<p style="margin-bottom:0.5rem;"><strong>Duração:</strong> ${trail.duration} h</p>` : ''}
-          <p style="margin-bottom:0.5rem;"><strong>Avaliação:</strong> ${trail.rating} / 5.0</p>
-          <p style="margin-bottom:0.5rem;"><strong>Pontos de água:</strong> ${trail.waterPoints ? 'Sim' : 'Não'}</p>
-          <p style="margin-bottom:0.5rem;"><strong>Pontos de camping:</strong> ${trail.campingPoints ? 'Sim' : 'Não'}</p>
-          <p style="margin-bottom:0.5rem;"><strong>Necessita guia:</strong> ${trail.requiresGuide ? 'Sim' : 'Não'}</p>
-          ${trail.entryFee && trail.entryFee > 0 ? `<p style="margin-bottom:0.5rem;"><strong>Taxa de entrada:</strong> R$ ${trail.entryFee.toFixed(2)}</p>` : ''}
-          <p>${trail.description}</p>
-        `;
-      }
-      if (detailsModal) detailsModal.classList.add('open');
-    }
-    if (detailsClose) {
-      detailsClose.addEventListener('click', () => detailsModal.classList.remove('open'));
-    }
-    if (detailsModal) {
-      detailsModal.addEventListener('click', (e) => {
-        if (e.target === detailsModal) detailsModal.classList.remove('open');
-      });
-    }
-    // Delegate click events on cards for details
-    trailsContainer.addEventListener('click', (e) => {
-      const btn = e.target.closest('button[data-id]');
-      if (btn) {
-        const id = btn.getAttribute('data-id');
-        openDetails(id);
-      }
-    });
   }
 
   /* Guias page logic */

--- a/styles/trilha.css
+++ b/styles/trilha.css
@@ -538,12 +538,43 @@ body.trail-page main {
   margin: 0;
 }
 
-.trail-final-cta .btn {
+.trail-final-cta__actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 0.75rem;
+  flex: 1 1 200px;
+}
+
+.trail-final-cta__actions .btn {
   background: #fff;
   color: var(--trekko-blue);
   border-radius: 999px;
   padding: 0.85rem 1.8rem;
   font-weight: 700;
+}
+
+.trail-final-cta__actions .btn.btn-secondary {
+  background: transparent;
+  color: #fff;
+  border: 2px solid rgba(255, 255, 255, 0.7);
+}
+
+.trail-final-cta__actions .btn.btn-secondary:hover,
+.trail-final-cta__actions .btn.btn-secondary:focus-visible {
+  background: rgba(255, 255, 255, 0.2);
+  border-color: #fff;
+}
+
+.trail-guides__actions {
+  margin-top: 1.5rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.trail-guides__actions .btn {
+  min-width: 220px;
 }
 
 .trail-floating-cta {

--- a/trilhas.html
+++ b/trilhas.html
@@ -126,14 +126,6 @@
         <div id="trailsContainer" class="cards-grid"></div>
     </main>
 
-    <!-- Trail Details Modal -->
-    <div id="trailDetailsModal" class="modal">
-        <div class="modal-content">
-            <button id="trailDetailsClose" class="modal-close">&times;</button>
-            <div id="trailDetailsContent"></div>
-        </div>
-    </div>
-
     <footer>
         <div class="footer-grid">
             <div>


### PR DESCRIPTION
## Summary
- turn the trail detail experience into a dedicated page with CTA buttons that deeplink to filtered guides and expeditions
- wire guide and trail datasets so the guides page can pre-filter by `?trail` and highlight the active filter with a dismissible banner
- add support for `?trail` on the expeditions list and simplify the trail catalog to open the detail page directly

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dafd30561883249afa6974492cdc21