### PR TITLE
Replace guide CTA with profile icon

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -28,7 +28,9 @@
                     <div id="searchSuggestions" class="suggestions"></div>
                 </div>
                 <div id="guideCTA" class="guide-cta">
-                    <a href="cadastrar_guia.html" class="btn btn-outline">Sou Guia</a>
+                    <a href="conta.html" class="btn btn-outline user-profile-icon" aria-label="Perfil do usuário">
+                        <i class="fas fa-user"></i>
+                    </a>
                 </div>
                 <div class="auth-buttons">
                     <button id="loginBtn" class="btn btn-secondary">Entrar</button>

--- a/ajuda.html
+++ b/ajuda.html
@@ -27,7 +27,11 @@
                     <input type="text" id="globalSearchInput" placeholder="Busque trilhas, guias, parques..." autocomplete="off">
                     <div id="searchSuggestions" class="suggestions"></div>
                 </div>
-                <div id="guideCTA" class="guide-cta"><a href="cadastrar_guia.html" class="btn btn-outline">Sou Guia</a></div>
+                <div id="guideCTA" class="guide-cta">
+                    <a href="conta.html" class="btn btn-outline user-profile-icon" aria-label="Perfil do usuário">
+                        <i class="fas fa-user"></i>
+                    </a>
+                </div>
                 <div class="auth-buttons">
                     <button id="loginBtn" class="btn btn-secondary">Entrar</button>
                     <button id="registerBtn" class="btn btn-primary">Cadastrar-se</button>

--- a/blog.html
+++ b/blog.html
@@ -27,7 +27,11 @@
                     <input type="text" id="globalSearchInput" placeholder="Busque trilhas, guias, parques..." autocomplete="off">
                     <div id="searchSuggestions" class="suggestions"></div>
                 </div>
-                <div id="guideCTA" class="guide-cta"><a href="cadastrar_guia.html" class="btn btn-outline">Sou Guia</a></div>
+                <div id="guideCTA" class="guide-cta">
+                    <a href="conta.html" class="btn btn-outline user-profile-icon" aria-label="Perfil do usuário">
+                        <i class="fas fa-user"></i>
+                    </a>
+                </div>
                 <div class="auth-buttons">
                     <button id="loginBtn" class="btn btn-secondary">Entrar</button>
                     <button id="registerBtn" class="btn btn-primary">Cadastrar-se</button>

--- a/blog_post.html
+++ b/blog_post.html
@@ -27,7 +27,11 @@
                     <input type="text" id="globalSearchInput" placeholder="Busque trilhas, guias, parques..." autocomplete="off">
                     <div id="searchSuggestions" class="suggestions"></div>
                 </div>
-                <div id="guideCTA" class="guide-cta"><a href="cadastrar_guia.html" class="btn btn-outline">Sou Guia</a></div>
+                <div id="guideCTA" class="guide-cta">
+                    <a href="conta.html" class="btn btn-outline user-profile-icon" aria-label="Perfil do usuário">
+                        <i class="fas fa-user"></i>
+                    </a>
+                </div>
                 <div class="auth-buttons">
                     <button id="loginBtn" class="btn btn-secondary">Entrar</button>
                     <button id="registerBtn" class="btn btn-primary">Cadastrar-se</button>

--- a/cadastrar.html
+++ b/cadastrar.html
@@ -36,7 +36,9 @@
                     <div id="searchSuggestions" class="suggestions"></div>
                 </div>
                 <div id="guideCTA" class="guide-cta">
-                    <a href="cadastrar_guia.html" class="btn btn-outline">Sou Guia</a>
+                    <a href="conta.html" class="btn btn-outline user-profile-icon" aria-label="Perfil do usuário">
+                        <i class="fas fa-user"></i>
+                    </a>
                 </div>
                 <!-- Ocultamos os botões de login/cadastro nesta página -->
                 <div class="auth-buttons" style="display:none;"></div>

--- a/checkout.html
+++ b/checkout.html
@@ -27,7 +27,11 @@
                     <input type="text" id="globalSearchInput" placeholder="Busque trilhas, guias, parques..." autocomplete="off">
                     <div id="searchSuggestions" class="suggestions"></div>
                 </div>
-                <div id="guideCTA" class="guide-cta"><a href="cadastrar_guia.html" class="btn btn-outline">Sou Guia</a></div>
+                <div id="guideCTA" class="guide-cta">
+                    <a href="conta.html" class="btn btn-outline user-profile-icon" aria-label="Perfil do usuário">
+                        <i class="fas fa-user"></i>
+                    </a>
+                </div>
                 <div class="auth-buttons">
                     <button id="loginBtn" class="btn btn-secondary">Entrar</button>
                     <button id="registerBtn" class="btn btn-primary">Cadastrar-se</button>

--- a/conta.html
+++ b/conta.html
@@ -28,7 +28,9 @@
                     <div id="searchSuggestions" class="suggestions"></div>
                 </div>
                 <div id="guideCTA" class="guide-cta">
-                    <a href="cadastrar_guia.html" class="btn btn-outline">Sou Guia</a>
+                    <a href="conta.html" class="btn btn-outline user-profile-icon" aria-label="Perfil do usuário">
+                        <i class="fas fa-user"></i>
+                    </a>
                 </div>
                 <div class="auth-buttons">
                     <button id="loginBtn" class="btn btn-secondary">Entrar</button>

--- a/entrar.html
+++ b/entrar.html
@@ -27,7 +27,11 @@
                     <input type="text" id="globalSearchInput" placeholder="Busque trilhas, guias, parques..." autocomplete="off">
                     <div id="searchSuggestions" class="suggestions"></div>
                 </div>
-                <div id="guideCTA" class="guide-cta"><a href="cadastrar_guia.html" class="btn btn-outline">Sou Guia</a></div>
+                <div id="guideCTA" class="guide-cta">
+                    <a href="conta.html" class="btn btn-outline user-profile-icon" aria-label="Perfil do usuário">
+                        <i class="fas fa-user"></i>
+                    </a>
+                </div>
                 <!-- Não mostrar botões de login/cadastro porque estamos na página de login -->
                 <div class="auth-buttons" style="display:none;"></div>
                 <div id="userNav" class="user-nav">

--- a/expedicao.html
+++ b/expedicao.html
@@ -28,7 +28,9 @@
                     <div id="searchSuggestions" class="suggestions"></div>
                 </div>
                 <div id="guideCTA" class="guide-cta">
-                    <a href="cadastrar_guia.html" class="btn btn-outline">Sou Guia</a>
+                    <a href="conta.html" class="btn btn-outline user-profile-icon" aria-label="Perfil do usuário">
+                        <i class="fas fa-user"></i>
+                    </a>
                 </div>
                 <div class="auth-buttons">
                     <button id="loginBtn" class="btn btn-secondary">Entrar</button>

--- a/expedicoes.html
+++ b/expedicoes.html
@@ -28,7 +28,9 @@
                     <div id="searchSuggestions" class="suggestions"></div>
                 </div>
                 <div id="guideCTA" class="guide-cta">
-                    <a href="cadastrar_guia.html" class="btn btn-outline">Sou Guia</a>
+                    <a href="conta.html" class="btn btn-outline user-profile-icon" aria-label="Perfil do usuário">
+                        <i class="fas fa-user"></i>
+                    </a>
                 </div>
                 <div class="auth-buttons">
                     <button id="loginBtn" class="btn btn-secondary">Entrar</button>

--- a/guia.html
+++ b/guia.html
@@ -27,7 +27,11 @@
                     <input type="text" id="globalSearchInput" placeholder="Busque trilhas, guias, parques..." autocomplete="off">
                     <div id="searchSuggestions" class="suggestions"></div>
                 </div>
-                <div id="guideCTA" class="guide-cta"><a href="cadastrar_guia.html" class="btn btn-outline">Sou Guia</a></div>
+                <div id="guideCTA" class="guide-cta">
+                    <a href="conta.html" class="btn btn-outline user-profile-icon" aria-label="Perfil do usuário">
+                        <i class="fas fa-user"></i>
+                    </a>
+                </div>
                 <div class="auth-buttons">
                     <button id="loginBtn" class="btn btn-secondary">Entrar</button>
                     <button id="registerBtn" class="btn btn-primary">Cadastrar-se</button>

--- a/guia_painel.html
+++ b/guia_painel.html
@@ -28,7 +28,9 @@
                     <div id="searchSuggestions" class="suggestions"></div>
                 </div>
                 <div id="guideCTA" class="guide-cta">
-                    <a href="cadastrar_guia.html" class="btn btn-outline">Sou Guia</a>
+                    <a href="conta.html" class="btn btn-outline user-profile-icon" aria-label="Perfil do usuário">
+                        <i class="fas fa-user"></i>
+                    </a>
                 </div>
                 <div class="auth-buttons">
                     <button id="loginBtn" class="btn btn-secondary">Entrar</button>

--- a/guias.html
+++ b/guias.html
@@ -337,7 +337,11 @@
           <input type="text" id="globalSearchInput" placeholder="Busque trilhas, guias, parques..." autocomplete="off">
           <div id="searchSuggestions" class="suggestions" role="listbox"></div>
         </div>
-        <div id="guideCTA" class="guide-cta"><a href="cadastrar_guia.html" class="btn btn-outline">Sou Guia</a></div>
+        <div id="guideCTA" class="guide-cta">
+          <a href="conta.html" class="btn btn-outline user-profile-icon" aria-label="Perfil do usuário">
+            <i class="fas fa-user" aria-hidden="true"></i>
+          </a>
+        </div>
         <div class="auth-buttons">
           <button id="loginBtn" class="btn btn-secondary">Entrar</button>
           <button id="registerBtn" class="btn btn-primary">Cadastrar-se</button>

--- a/index.html
+++ b/index.html
@@ -36,7 +36,9 @@
                 </div>
                 <!-- CTA for becoming a guide -->
                 <div id="guideCTA" class="guide-cta">
-                    <a href="cadastrar_guia.html" class="btn btn-outline">Sou Guia</a>
+                    <a href="conta.html" class="btn btn-outline user-profile-icon" aria-label="Perfil do usuário">
+                        <i class="fas fa-user"></i>
+                    </a>
                 </div>
                 <!-- Auth buttons visible when no user is logged in -->
                 <div class="auth-buttons">

--- a/politicas/cancelamento.html
+++ b/politicas/cancelamento.html
@@ -27,7 +27,11 @@
                     <input type="text" id="globalSearchInput" placeholder="Busque trilhas, guias, parques..." autocomplete="off">
                     <div id="searchSuggestions" class="suggestions"></div>
                 </div>
-                <div id="guideCTA" class="guide-cta"><a href="../cadastrar_guia.html" class="btn btn-outline">Sou Guia</a></div>
+                <div id="guideCTA" class="guide-cta">
+                    <a href="../conta.html" class="btn btn-outline user-profile-icon" aria-label="Perfil do usuário">
+                        <i class="fas fa-user"></i>
+                    </a>
+                </div>
                 <div class="auth-buttons">
                     <button id="loginBtn" class="btn btn-secondary">Entrar</button>
                     <button id="registerBtn" class="btn btn-primary">Cadastrar-se</button>

--- a/recuperar-senha.html
+++ b/recuperar-senha.html
@@ -28,7 +28,11 @@
                     <input type="text" id="globalSearchInput" placeholder="Busque trilhas, guias, parques..." autocomplete="off">
                     <div id="searchSuggestions" class="suggestions"></div>
                 </div>
-                <div id="guideCTA" class="guide-cta"><a href="cadastrar_guia.html" class="btn btn-outline">Sou Guia</a></div>
+                <div id="guideCTA" class="guide-cta">
+                    <a href="conta.html" class="btn btn-outline user-profile-icon" aria-label="Perfil do usuário">
+                        <i class="fas fa-user"></i>
+                    </a>
+                </div>
                 <!-- Não mostrar botões de login/cadastro porque estamos numa página de recuperação -->
                 <div class="auth-buttons" style="display:none;"></div>
                 <div id="userNav" class="user-nav">

--- a/resetar-senha.html
+++ b/resetar-senha.html
@@ -27,7 +27,11 @@
                     <input type="text" id="globalSearchInput" placeholder="Busque trilhas, guias, parques..." autocomplete="off">
                     <div id="searchSuggestions" class="suggestions"></div>
                 </div>
-                <div id="guideCTA" class="guide-cta"><a href="cadastrar_guia.html" class="btn btn-outline">Sou Guia</a></div>
+                <div id="guideCTA" class="guide-cta">
+                    <a href="conta.html" class="btn btn-outline user-profile-icon" aria-label="Perfil do usuário">
+                        <i class="fas fa-user"></i>
+                    </a>
+                </div>
                 <div class="auth-buttons" style="display:none;"></div>
                 <div id="userNav" class="user-nav">
                     <button class="user-button"><i class="fas fa-user"></i> <span class="user-name"></span> <i class="fas fa-chevron-down"></i></button>

--- a/sobre.html
+++ b/sobre.html
@@ -32,7 +32,9 @@
                     <div id="searchSuggestions" class="suggestions"></div>
                 </div>
                 <div id="guideCTA" class="guide-cta">
-                    <a href="cadastrar_guia.html" class="btn btn-outline">Sou Guia</a>
+                    <a href="conta.html" class="btn btn-outline user-profile-icon" aria-label="Perfil do usuário">
+                        <i class="fas fa-user"></i>
+                    </a>
                 </div>
                 <div class="auth-buttons">
                     <button id="loginBtn" class="btn btn-secondary">Entrar</button>

--- a/styles.css
+++ b/styles.css
@@ -171,6 +171,20 @@ header {
   gap: 1rem;
 }
 
+.guide-cta .user-profile-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.75rem;
+  height: 2.75rem;
+  padding: 0;
+  font-size: 1.125rem;
+}
+
+.guide-cta .user-profile-icon i {
+  pointer-events: none;
+}
+
 .mobile-menu-btn {
   display: none;
   font-size: 1.5rem;

--- a/trilhas.html
+++ b/trilhas.html
@@ -32,7 +32,9 @@
                     <div id="searchSuggestions" class="suggestions"></div>
                 </div>
                 <div id="guideCTA" class="guide-cta">
-                    <a href="cadastrar_guia.html" class="btn btn-outline">Sou Guia</a>
+                    <a href="conta.html" class="btn btn-outline user-profile-icon" aria-label="Perfil do usuário">
+                        <i class="fas fa-user"></i>
+                    </a>
                 </div>
                 <div class="auth-buttons">
                     <button id="loginBtn" class="btn btn-secondary">Entrar</button>


### PR DESCRIPTION
## Summary
- replace the "Sou Guia" call-to-action in navigation headers with a user profile icon that links to the account page
- add dedicated styling so the new icon button matches the navigation layout

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68db013699dc83248cbeee3b1bcdaa82