### PR TITLE
Ensure guide sessions sync with database

### DIFF
--- a/auth.js
+++ b/auth.js
@@ -280,7 +280,25 @@ const Auth = (() => {
     if (!user.isVerified) {
       throw new Error('Conta ainda não verificada. Verifique seu e-mail.');
     }
-    const payload = { id: user.id, email: user.email, type: user.type, name: user.name, exp: Math.floor(Date.now() / 1000) + 60 * 60 * 24 * 7 };
+    const rawSpecialties = Array.isArray(user.specialties)
+      ? user.specialties
+      : Array.isArray(user.parks)
+        ? user.parks
+        : [];
+    const payload = {
+      id: user.id,
+      email: user.email,
+      type: user.type,
+      name: user.name,
+      cadastur: user.cadastur || '',
+      phone: user.phone || '',
+      state: user.state || '',
+      city: user.city || '',
+      specialties: rawSpecialties.map((item) =>
+        typeof item === 'string' ? item : typeof item === 'number' ? item.toString() : ''
+      ).filter(Boolean),
+      exp: Math.floor(Date.now() / 1000) + 60 * 60 * 24 * 7
+    };
     const token = await generateJWT(payload);
     // Save session
     localStorage.setItem(SESSION_KEY, JSON.stringify({ token, user: payload }));

--- a/pages/api/expeditions/index.ts
+++ b/pages/api/expeditions/index.ts
@@ -1,5 +1,5 @@
 import type { NextApiRequest, NextApiResponse } from 'next'
-import { Prisma, ExpeditionStatus } from '@prisma/client'
+import { Prisma, ExpeditionStatus, UserRole } from '@prisma/client'
 
 import prisma from '../../../lib/prisma'
 import { verifyAuthToken } from '../../../lib/authToken'
@@ -89,7 +89,113 @@ async function resolveAuthenticatedGuide(payload: Awaited<ReturnType<typeof veri
     }
   }
 
+  const ensured = await ensureGuideUserFromPayload(payload)
+  if (ensured) {
+    return ensured
+  }
+
   return null
+}
+
+function normalizeString(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : ''
+}
+
+function parseOptionalDate(value: unknown): Date | null {
+  if (!value) {
+    return null
+  }
+  const str = typeof value === 'string' || typeof value === 'number' ? String(value) : ''
+  if (!str.trim()) {
+    return null
+  }
+  const parsed = new Date(str)
+  if (Number.isNaN(parsed.getTime())) {
+    return null
+  }
+  return parsed
+}
+
+async function ensureGuideUserFromPayload(payload: Awaited<ReturnType<typeof verifyAuthToken>>): Promise<GuideUser | null> {
+  const email = normalizeString(payload?.email)
+  if (!email) {
+    return null
+  }
+
+  const cadastur = normalizeString(payload?.cadastur)
+  if (!cadastur) {
+    return null
+  }
+
+  const existing = await findGuideUserByEmail(email)
+  if (existing) {
+    return existing
+  }
+
+  const name = normalizeString(payload?.name) || email
+  const phone = normalizeString((payload as { phone?: unknown })?.phone)
+  const state = normalizeString((payload as { state?: unknown })?.state).toUpperCase() || null
+  const city = normalizeString((payload as { city?: unknown })?.city) || null
+  const validity = parseOptionalDate((payload as { validity?: unknown; cadasturValidity?: unknown })?.validity)
+    || parseOptionalDate((payload as { validity?: unknown; cadasturValidity?: unknown })?.cadasturValidity)
+  const specialtiesRaw = Array.isArray((payload as { specialties?: unknown })?.specialties)
+    ? (payload as { specialties: unknown[] }).specialties
+    : []
+  const specialties = specialtiesRaw
+    .map(item => {
+      if (typeof item === 'string') {
+        return item.trim()
+      }
+      if (typeof item === 'number') {
+        return item.toString()
+      }
+      return ''
+    })
+    .filter(Boolean)
+    .join(', ')
+
+  const guide = await prisma.guide.upsert({
+    where: { cadastur },
+    create: {
+      name,
+      email,
+      phone: phone || null,
+      cadastur,
+      uf: state,
+      city,
+      validity,
+      specialties: specialties || null
+    },
+    update: {
+      name,
+      email,
+      phone: phone || null,
+      uf: state,
+      city,
+      validity,
+      specialties: specialties || null
+    }
+  })
+
+  const user = await prisma.user.upsert({
+    where: { email },
+    create: {
+      email,
+      name,
+      role: UserRole.guide,
+      guideId: guide.id
+    },
+    update: {
+      name,
+      role: UserRole.guide,
+      guideId: guide.id
+    }
+  })
+
+  return prisma.user.findUnique({
+    where: { id: user.id },
+    include: { guide: true }
+  })
 }
 
 async function handleGet(req: NextApiRequest, res: NextApiResponse) {


### PR DESCRIPTION
## Summary
- enrich client authentication payloads with guide details so the API can create matching records
- extend expedition creation API to automatically provision guide and user records from session payloads
- ensure authenticated guides are recognized when publishing new expeditions

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dc1e4b0a388324b7115d6bbe491f8c