### PR TITLE
Add CORS support to expeditions API endpoints

### DIFF
--- a/pages/api/expeditions/[id].ts
+++ b/pages/api/expeditions/[id].ts
@@ -17,6 +17,15 @@ function toNumber(value: string | string[] | undefined): number | null {
 }
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  res.setHeader('Access-Control-Allow-Origin', '*')
+  res.setHeader('Access-Control-Allow-Methods', 'GET,OPTIONS')
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization')
+
+  if (req.method === 'OPTIONS') {
+    res.status(204).end()
+    return
+  }
+
   if (req.method !== 'GET') {
     res.setHeader('Allow', ['GET'])
     return res.status(405).json({ message: 'Método não permitido.' })

--- a/pages/api/expeditions/index.ts
+++ b/pages/api/expeditions/index.ts
@@ -198,6 +198,19 @@ async function ensureGuideUserFromPayload(payload: Awaited<ReturnType<typeof ver
   })
 }
 
+function applyCors(req: NextApiRequest, res: NextApiResponse): boolean {
+  res.setHeader('Access-Control-Allow-Origin', '*')
+  res.setHeader('Access-Control-Allow-Methods', 'GET,POST,OPTIONS')
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization')
+
+  if (req.method === 'OPTIONS') {
+    res.status(204).end()
+    return true
+  }
+
+  return false
+}
+
 async function handleGet(req: NextApiRequest, res: NextApiResponse) {
   const statusQuery = getQueryValue(req.query.status).toLowerCase() || 'active'
   const searchQuery = getQueryValue(req.query.search)
@@ -475,6 +488,10 @@ async function handlePost(req: NextApiRequest, res: NextApiResponse) {
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   try {
+    if (applyCors(req, res)) {
+      return
+    }
+
     if (req.method === 'GET') {
       return await handleGet(req, res)
     }


### PR DESCRIPTION
## Summary
- add a reusable CORS helper to the expeditions list/create endpoint
- expose cross-origin headers and handle OPTIONS requests for both expeditions endpoints

## Testing
- npm run lint *(fails: command becomes interactive and prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68dc3304ca9883248c3ec2d92d1f2f82