### PR TITLE
Fix expedition creation errors and improve messaging

### DIFF
--- a/criar-expedicao.html
+++ b/criar-expedicao.html
@@ -674,10 +674,18 @@
                     }
                     const data = await response.json().catch(() => ({}));
                     if (!response.ok) {
-                        throw new Error(data?.message || 'Não foi possível criar a expedição.');
+                        let errorMessage = data?.message || 'Não foi possível criar a expedição.';
+                        if (response.status === 400) {
+                            errorMessage = 'Verifique os campos obrigatórios.';
+                        } else if (response.status === 401 || response.status === 403) {
+                            errorMessage = 'Você não tem permissão para criar expedições.';
+                        } else if (response.status >= 500) {
+                            errorMessage = 'Erro interno do servidor, tente novamente mais tarde.';
+                        }
+                        throw new Error(errorMessage);
                     }
                     if (feedbackMessage) {
-                        feedbackMessage.textContent = 'Expedição publicada com sucesso! Redirecionando...';
+                        feedbackMessage.textContent = 'Expedição criada com sucesso. Redirecionando...';
                         feedbackMessage.classList.add('success');
                     }
                     if (typeof expeditionService !== 'undefined' && expeditionService.clearCache) {

--- a/pages/api/expeditions/index.ts
+++ b/pages/api/expeditions/index.ts
@@ -1,3 +1,4 @@
+import crypto from 'crypto'
 import type { NextApiRequest, NextApiResponse } from 'next'
 import { Prisma, ExpeditionStatus, UserRole } from '@prisma/client'
 
@@ -7,6 +8,10 @@ import { verifyAuthToken } from '../../../lib/authToken'
 const MAX_PAGE_SIZE = 50
 
 type GuideUser = Prisma.UserGetPayload<{ include: { guide: true } }>
+
+function generatePlaceholderPassword(): string {
+  return crypto.randomBytes(32).toString('hex')
+}
 
 function getQueryValue(value: string | string[] | undefined): string {
   if (Array.isArray(value)) {
@@ -182,6 +187,7 @@ async function ensureGuideUserFromPayload(payload: Awaited<ReturnType<typeof ver
     create: {
       email,
       name,
+      password: generatePlaceholderPassword(),
       role: UserRole.guide,
       guideId: guide.id
     },


### PR DESCRIPTION
## Summary
- ensure guide accounts created from auth tokens receive a placeholder password when provisioned in the API
- refine expedition creation form messaging to show user-friendly feedback for validation, permission, and server errors

## Testing
- npm test *(fails: Prisma client missing CadasturGuide types)*

------
https://chatgpt.com/codex/tasks/task_e_68dd9664a6cc8324a051abf4cf8542a5