### PR TITLE
Improve default network error guidance

### DIFF
--- a/scripts.js
+++ b/scripts.js
@@ -184,8 +184,10 @@ function normaliseApiBase(base) {
   return trimmed.replace(/\/+$/, '')
 }
 
+const DEFAULT_NETWORK_ERROR_MESSAGE = 'Servidor indisponível ou bloqueio de CORS. Verifique HTTPS e permissões da API.'
+
 function createNetworkError(message, originalError) {
-  const error = new Error(message || 'Servidor indisponível, tente novamente.')
+  const error = new Error(message || DEFAULT_NETWORK_ERROR_MESSAGE)
   error.name = 'NetworkError'
   if (originalError && typeof originalError === 'object') {
     try {


### PR DESCRIPTION
## Summary
- clarify the default network error message to mention possible CORS and HTTPS issues

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ddb127a0d48324815ba37037765690