### PR TITLE
Create expedition creation workflow

### DIFF
--- a/expedicoes.html
+++ b/expedicoes.html
@@ -62,7 +62,7 @@
     <main class="container" style="padding-top:2rem;">
         <h1 style="font-family:'Sora',sans-serif;color:var(--color-primary);margin-bottom:1.5rem;">Expedições</h1>
         <div id="guideExpeditionActions" class="guide-expedition-actions">
-            <a href="criar-expedicao.html" class="btn btn-primary">Criar nova expedição</a>
+            <a href="/criar-expedicao" class="btn btn-primary">Criar Expedição</a>
         </div>
         <div class="expeditions-filters" style="display:flex;flex-wrap:wrap;gap:1rem;margin-bottom:1.5rem;">
             <input type="text" id="expSearchFilter" placeholder="Buscar expedição ou trilha" style="flex:1 1 200px;padding:0.6rem;border:1px solid #ccc;border-radius:4px;" />

--- a/pages/api/expeditions/[id].ts
+++ b/pages/api/expeditions/[id].ts
@@ -70,6 +70,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       endDate: expedition.endDate.toISOString(),
       pricePerPerson: Number(expedition.pricePerPerson),
       maxPeople: expedition.maxPeople,
+      images: expedition.images ?? [],
       status: expedition.status,
       createdAt: expedition.createdAt.toISOString(),
       updatedAt: expedition.updatedAt.toISOString(),

--- a/pages/api/expeditions/index.ts
+++ b/pages/api/expeditions/index.ts
@@ -6,6 +6,95 @@ import prisma from '../../../lib/prisma'
 import { verifyAuthToken } from '../../../lib/authToken'
 
 const MAX_PAGE_SIZE = 50
+const MAX_UPLOAD_IMAGES = 5
+const ACCEPTED_IMAGE_MIME_TYPES = new Set(['image/jpeg', 'image/png', 'image/webp'])
+const ACCEPTED_IMAGE_EXTENSIONS = ['.jpg', '.jpeg', '.png', '.webp']
+
+function parseBrazilianDateString(value: string): Date | null {
+  const match = /^(\d{2})\/(\d{2})\/(\d{4})$/.exec(value.trim())
+  if (!match) {
+    return null
+  }
+
+  const [, dayStr, monthStr, yearStr] = match
+  const day = Number.parseInt(dayStr, 10)
+  const monthIndex = Number.parseInt(monthStr, 10) - 1
+  const year = Number.parseInt(yearStr, 10)
+
+  if (
+    Number.isNaN(day)
+    || Number.isNaN(monthIndex)
+    || Number.isNaN(year)
+    || day < 1
+    || monthIndex < 0
+    || monthIndex > 11
+    || year < 1900
+  ) {
+    return null
+  }
+
+  const date = new Date(Date.UTC(year, monthIndex, day))
+  if (
+    date.getUTCFullYear() !== year
+    || date.getUTCMonth() !== monthIndex
+    || date.getUTCDate() !== day
+  ) {
+    return null
+  }
+
+  return date
+}
+
+function isAllowedImagePayload(value: string): boolean {
+  const trimmed = value.trim()
+  if (!trimmed) {
+    return false
+  }
+
+  if (trimmed.startsWith('data:')) {
+    const match = /^data:(image\/[a-z0-9+.-]+);base64,/i.exec(trimmed)
+    if (!match) {
+      return false
+    }
+    return ACCEPTED_IMAGE_MIME_TYPES.has(match[1].toLowerCase())
+  }
+
+  if (/^https?:\/\//i.test(trimmed)) {
+    const lower = trimmed.toLowerCase()
+    return ACCEPTED_IMAGE_EXTENSIONS.some(ext => lower.endsWith(ext))
+  }
+
+  return false
+}
+
+function sanitizeImageArray(input: unknown): string[] {
+  if (input === undefined || input === null) {
+    return []
+  }
+  if (!Array.isArray(input)) {
+    throw new Error('INVALID_IMAGE_PAYLOAD')
+  }
+  if (input.length > MAX_UPLOAD_IMAGES) {
+    throw new Error('TOO_MANY_IMAGES')
+  }
+
+  const sanitized: string[] = []
+  for (const value of input) {
+    if (typeof value !== 'string') {
+      throw new Error('INVALID_IMAGE_PAYLOAD')
+    }
+    const trimmed = value.trim()
+    if (!trimmed) {
+      continue
+    }
+    if (!isAllowedImagePayload(trimmed)) {
+      throw new Error('INVALID_IMAGE_TYPE')
+    }
+    sanitized.push(trimmed)
+  }
+
+  return sanitized
+}
 
 type GuideUser = Prisma.UserGetPayload<{ include: { guide: true } }>
 
@@ -40,7 +129,17 @@ function parseDate(value: string): Date | null {
   if (!value) {
     return null
   }
-  const date = new Date(value)
+  const trimmed = value.trim()
+  if (!trimmed) {
+    return null
+  }
+
+  const brazilianFormat = parseBrazilianDateString(trimmed)
+  if (brazilianFormat) {
+    return brazilianFormat
+  }
+
+  const date = new Date(trimmed)
   if (Number.isNaN(date.getTime())) {
     return null
   }
@@ -50,6 +149,10 @@ function parseDate(value: string): Date | null {
 function startOfToday(): Date {
   const now = new Date()
   return new Date(now.getFullYear(), now.getMonth(), now.getDate())
+}
+
+function normalizeToStartOfDay(date: Date): Date {
+  return new Date(date.getFullYear(), date.getMonth(), date.getDate())
 }
 
 async function findGuideUserByEmail(email: string): Promise<GuideUser | null> {
@@ -342,6 +445,7 @@ async function handleGet(req: NextApiRequest, res: NextApiResponse) {
     endDate: expedition.endDate.toISOString(),
     pricePerPerson: Number(expedition.pricePerPerson),
     maxPeople: expedition.maxPeople,
+    images: expedition.images ?? [],
     status: expedition.status,
     createdAt: expedition.createdAt.toISOString(),
     updatedAt: expedition.updatedAt.toISOString(),
@@ -416,7 +520,8 @@ async function handlePost(req: NextApiRequest, res: NextApiResponse) {
     startDate,
     endDate,
     pricePerPerson,
-    maxPeople
+    maxPeople,
+    images
   } = req.body as Record<string, unknown>
 
   const normalizedTrailId = String(trailId ?? '').trim()
@@ -424,20 +529,17 @@ async function handlePost(req: NextApiRequest, res: NextApiResponse) {
     return res.status(400).json({ message: 'Trilha obrigatória.' })
   }
 
-  const normalizedTitle = String(title ?? '').trim()
-  if (!normalizedTitle) {
-    return res.status(400).json({ message: 'Título é obrigatório.' })
-  }
+  const normalizedTitleInput = typeof title === 'string' ? title.trim() : ''
 
   const normalizedDescription = String(description ?? '').trim()
   if (!normalizedDescription) {
     return res.status(400).json({ message: 'Descrição é obrigatória.' })
   }
-
-  const normalizedDifficulty = String(difficultyLevel ?? '').trim()
-  if (!normalizedDifficulty) {
-    return res.status(400).json({ message: 'Nível de dificuldade é obrigatório.' })
+  if (normalizedDescription.length < 50) {
+    return res.status(400).json({ message: 'Descrição deve ter pelo menos 50 caracteres.' })
   }
+
+  const normalizedDifficultyInput = typeof difficultyLevel === 'string' ? difficultyLevel.trim() : ''
 
   const start = parseDate(String(startDate ?? ''))
   const end = parseDate(String(endDate ?? ''))
@@ -445,8 +547,16 @@ async function handlePost(req: NextApiRequest, res: NextApiResponse) {
     return res.status(400).json({ message: 'Datas inválidas.' })
   }
 
-  if (end < start) {
-    return res.status(400).json({ message: 'Data de término deve ser posterior à data de início.' })
+  const normalizedStart = normalizeToStartOfDay(start)
+  const normalizedEnd = normalizeToStartOfDay(end)
+  const today = startOfToday()
+
+  if (normalizedStart < today) {
+    return res.status(400).json({ message: 'Data inicial deve ser igual ou posterior à data atual.' })
+  }
+
+  if (normalizedEnd < normalizedStart) {
+    return res.status(400).json({ message: 'Data final deve ser igual ou posterior à data inicial.' })
   }
 
   const price = typeof pricePerPerson === 'string' || typeof pricePerPerson === 'number'
@@ -463,35 +573,51 @@ async function handlePost(req: NextApiRequest, res: NextApiResponse) {
     return res.status(400).json({ message: 'Número máximo de pessoas inválido.' })
   }
 
+  let sanitizedImages: string[] = []
+  try {
+    sanitizedImages = sanitizeImageArray(images as unknown)
+  } catch (error) {
+    const code = (error as Error).message
+    if (code === 'TOO_MANY_IMAGES') {
+      return res.status(400).json({ message: 'É permitido enviar até 5 imagens.' })
+    }
+    return res.status(400).json({ message: 'Imagens inválidas. Utilize arquivos JPG, PNG ou WEBP.' })
+  }
+
+  const persistedTrailName = String(trailName ?? '').trim()
   const persistedTrail = await prisma.trail.upsert({
     where: { id: normalizedTrailId },
     create: {
       id: normalizedTrailId,
-      name: String(trailName ?? normalizedTitle).trim() || normalizedTitle,
+      name: persistedTrailName || normalizedTitleInput || normalizedTrailId,
       state: String(trailState ?? '').trim() || null,
       city: String(trailCity ?? '').trim() || null,
       park: String(trailPark ?? '').trim() || null
     },
     update: {
-      name: String(trailName ?? normalizedTitle).trim() || normalizedTitle,
+      name: persistedTrailName || normalizedTitleInput || normalizedTrailId,
       state: String(trailState ?? '').trim() || null,
       city: String(trailCity ?? '').trim() || null,
       park: String(trailPark ?? '').trim() || null
     }
   })
 
+  const finalTitle = normalizedTitleInput || `Expedição ${persistedTrail.name}`
+  const finalDifficulty = normalizedDifficultyInput || 'personalizado'
+
   const expedition = await prisma.expedition.create({
     data: {
       trailId: persistedTrail.id,
       guideUserId: user.id,
-      title: normalizedTitle,
+      title: finalTitle,
       description: normalizedDescription,
       highlights: String(highlights ?? '').trim() || null,
-      difficultyLevel: normalizedDifficulty,
-      startDate: start,
-      endDate: end,
+      difficultyLevel: finalDifficulty,
+      startDate: normalizedStart,
+      endDate: normalizedEnd,
       pricePerPerson: new Prisma.Decimal(price.toFixed(2)),
       maxPeople: maxPeopleValue,
+      images: sanitizedImages,
       status: ExpeditionStatus.ACTIVE
     }
   })

--- a/pages/api/trails/index.ts
+++ b/pages/api/trails/index.ts
@@ -1,0 +1,146 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import { Prisma } from '@prisma/client'
+
+import prisma from '../../../lib/prisma'
+
+const MAX_PAGE_SIZE = 50
+
+function applyCors(req: NextApiRequest, res: NextApiResponse): boolean {
+  const requestOrigin = typeof req.headers.origin === 'string' ? req.headers.origin : '*'
+  res.setHeader('Access-Control-Allow-Origin', requestOrigin)
+  res.setHeader('Vary', 'Origin')
+  res.setHeader('Access-Control-Allow-Methods', 'GET,OPTIONS')
+  const requestedHeaders =
+    typeof req.headers['access-control-request-headers'] === 'string'
+      ? req.headers['access-control-request-headers']
+      : 'Content-Type, Authorization, Accept'
+  res.setHeader('Access-Control-Allow-Headers', requestedHeaders)
+
+  if (req.method === 'OPTIONS') {
+    res.status(204).end()
+    return true
+  }
+
+  return false
+}
+
+function getQueryValue(value: string | string[] | undefined): string {
+  if (Array.isArray(value)) {
+    return value[0] ?? ''
+  }
+  return value ?? ''
+}
+
+function parsePage(value: string): number {
+  const parsed = Number.parseInt(value, 10)
+  if (Number.isNaN(parsed) || parsed < 1) {
+    return 1
+  }
+  return parsed
+}
+
+function parsePageSize(value: string): number {
+  const parsed = Number.parseInt(value, 10)
+  if (Number.isNaN(parsed) || parsed < 1) {
+    return 20
+  }
+  return Math.min(parsed, MAX_PAGE_SIZE)
+}
+
+function buildSearchFilter(search: string): Prisma.TrailWhereInput | null {
+  if (!search) {
+    return null
+  }
+  return {
+    OR: [
+      { name: { contains: search, mode: 'insensitive' } },
+      { city: { contains: search, mode: 'insensitive' } },
+      { state: { contains: search, mode: 'insensitive' } },
+      { park: { contains: search, mode: 'insensitive' } }
+    ]
+  }
+}
+
+async function handleGet(req: NextApiRequest, res: NextApiResponse) {
+  const searchQuery = getQueryValue(req.query.search)
+  const stateQuery = getQueryValue(req.query.state)
+  const cityQuery = getQueryValue(req.query.city)
+  const nameQuery = getQueryValue(req.query.name || req.query.trail)
+  const parkQuery = getQueryValue(req.query.park)
+  const pageQuery = getQueryValue(req.query.page) || '1'
+  const pageSizeQuery = getQueryValue(req.query.pageSize) || '20'
+
+  const page = parsePage(pageQuery)
+  const pageSize = parsePageSize(pageSizeQuery)
+  const skip = (page - 1) * pageSize
+
+  const filters: Prisma.TrailWhereInput[] = []
+  const searchFilter = buildSearchFilter(searchQuery)
+  if (searchFilter) {
+    filters.push(searchFilter)
+  }
+
+  if (stateQuery) {
+    filters.push({ state: { equals: stateQuery, mode: 'insensitive' } })
+  }
+
+  if (cityQuery) {
+    filters.push({ city: { contains: cityQuery, mode: 'insensitive' } })
+  }
+
+  if (nameQuery) {
+    filters.push({ name: { contains: nameQuery, mode: 'insensitive' } })
+  }
+
+  if (parkQuery) {
+    filters.push({ park: { contains: parkQuery, mode: 'insensitive' } })
+  }
+
+  const where: Prisma.TrailWhereInput = filters.length ? { AND: filters } : {}
+
+  const [total, trails] = await prisma.$transaction([
+    prisma.trail.count({ where }),
+    prisma.trail.findMany({
+      where,
+      orderBy: { name: 'asc' },
+      skip,
+      take: pageSize
+    })
+  ])
+
+  const data = trails.map(trail => ({
+    id: trail.id,
+    name: trail.name,
+    state: trail.state,
+    city: trail.city,
+    park: trail.park
+  }))
+
+  return res.status(200).json({
+    data,
+    pagination: {
+      page,
+      pageSize,
+      total,
+      totalPages: pageSize > 0 ? Math.ceil(total / pageSize) : 0
+    }
+  })
+}
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  try {
+    if (applyCors(req, res)) {
+      return
+    }
+
+    if (req.method === 'GET') {
+      return await handleGet(req, res)
+    }
+
+    res.setHeader('Allow', ['GET'])
+    return res.status(405).json({ message: 'Método não permitido.' })
+  } catch (error) {
+    console.error('Failed to handle /api/trails request', error)
+    return res.status(500).json({ message: 'Erro interno ao processar a requisição.' })
+  }
+}

--- a/pages/criar-expedicao.tsx
+++ b/pages/criar-expedicao.tsx
@@ -1,0 +1,836 @@
+import { FormEvent, useCallback, useEffect, useMemo, useState } from 'react'
+import Head from 'next/head'
+
+import styles from '../styles/CreateExpedition.module.css'
+
+const ACCEPTED_IMAGE_TYPES = ['image/jpeg', 'image/png', 'image/webp']
+const MAX_IMAGES = 5
+const MAX_IMAGE_SIZE_BYTES = 5 * 1024 * 1024
+
+interface Trail {
+  id: string
+  name: string
+  state: string | null
+  city: string | null
+  park: string | null
+}
+
+interface SessionUser {
+  type?: string
+  cadastur?: string
+  name?: string
+  [key: string]: unknown
+}
+
+interface SessionData {
+  token: string
+  user: SessionUser
+}
+
+interface UploadedImage {
+  name: string
+  size: number
+  dataUrl: string
+}
+
+function formatDateInput(value: string): string {
+  const digits = value.replace(/\D/g, '').slice(0, 8)
+  if (!digits) {
+    return ''
+  }
+  if (digits.length <= 2) {
+    return digits
+  }
+  if (digits.length <= 4) {
+    return `${digits.slice(0, 2)}/${digits.slice(2)}`
+  }
+  return `${digits.slice(0, 2)}/${digits.slice(2, 4)}/${digits.slice(4)}`
+}
+
+function parseBrazilianDate(value: string): Date | null {
+  const match = /^(\d{2})\/(\d{2})\/(\d{4})$/.exec(value.trim())
+  if (!match) {
+    return null
+  }
+  const [, dayStr, monthStr, yearStr] = match
+  const day = Number.parseInt(dayStr, 10)
+  const monthIndex = Number.parseInt(monthStr, 10) - 1
+  const year = Number.parseInt(yearStr, 10)
+
+  if (
+    Number.isNaN(day)
+    || Number.isNaN(monthIndex)
+    || Number.isNaN(year)
+    || day < 1
+    || monthIndex < 0
+    || monthIndex > 11
+    || year < 1900
+  ) {
+    return null
+  }
+
+  const date = new Date(Date.UTC(year, monthIndex, day))
+  if (
+    date.getUTCFullYear() !== year
+    || date.getUTCMonth() !== monthIndex
+    || date.getUTCDate() !== day
+  ) {
+    return null
+  }
+  return date
+}
+
+function toISODateString(date: Date): string {
+  const year = date.getUTCFullYear()
+  const month = String(date.getUTCMonth() + 1).padStart(2, '0')
+  const day = String(date.getUTCDate()).padStart(2, '0')
+  return `${year}-${month}-${day}`
+}
+
+function normalizeToStartOfDay(date: Date): Date {
+  return new Date(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate())
+}
+
+function parseCurrency(value: string): number {
+  if (!value) {
+    return Number.NaN
+  }
+  const normalized = value.replace(/\s/g, '').replace(/\./g, '').replace(',', '.')
+  return Number(normalized)
+}
+
+function formatCurrencyInput(value: string): string {
+  const digits = value.replace(/\D/g, '')
+  if (!digits) {
+    return ''
+  }
+  const number = Number(digits) / 100
+  return number.toLocaleString('pt-BR', { minimumFractionDigits: 2, maximumFractionDigits: 2 })
+}
+
+function buildTrailLocation(trail: Trail): string {
+  const parts = [trail.city, trail.state].filter(Boolean)
+  const location = parts.join(' • ')
+  if (trail.park) {
+    return location ? `${location} • ${trail.park}` : trail.park
+  }
+  return location
+}
+
+type FormErrors = {
+  trail: string
+  startDate: string
+  endDate: string
+  price: string
+  maxPeople: string
+  description: string
+  images: string
+}
+
+const INITIAL_TOUCHED: Record<keyof FormErrors, boolean> = {
+  trail: false,
+  startDate: false,
+  endDate: false,
+  price: false,
+  maxPeople: false,
+  description: false,
+  images: false
+}
+
+const ALL_TOUCHED: Record<keyof FormErrors, boolean> = {
+  trail: true,
+  startDate: true,
+  endDate: true,
+  price: true,
+  maxPeople: true,
+  description: true,
+  images: true
+}
+
+const INITIAL_ERRORS: FormErrors = {
+  trail: '',
+  startDate: '',
+  endDate: '',
+  price: '',
+  maxPeople: '',
+  description: '',
+  images: ''
+}
+
+export default function CreateExpeditionPage() {
+  const [sessionState, setSessionState] = useState<'loading' | 'unauthenticated' | 'forbidden' | 'ready'>('loading')
+  const [session, setSession] = useState<SessionData | null>(null)
+
+  const [selectedTrail, setSelectedTrail] = useState<Trail | null>(null)
+  const [trailSearch, setTrailSearch] = useState('')
+  const [trailStateFilter, setTrailStateFilter] = useState('')
+  const [trailCityFilter, setTrailCityFilter] = useState('')
+  const [trailPage, setTrailPage] = useState(1)
+  const [trailTotalPages, setTrailTotalPages] = useState(1)
+  const [trailResults, setTrailResults] = useState<Trail[]>([])
+  const [isLoadingTrails, setIsLoadingTrails] = useState(false)
+  const [trailError, setTrailError] = useState<string | null>(null)
+
+  const [startDate, setStartDate] = useState('')
+  const [endDate, setEndDate] = useState('')
+  const [price, setPrice] = useState('')
+  const [maxPeople, setMaxPeople] = useState('')
+  const [description, setDescription] = useState('')
+  const [uploadedImages, setUploadedImages] = useState<UploadedImage[]>([])
+  const [imageUploadError, setImageUploadError] = useState<string | null>(null)
+
+  const [touched, setTouched] = useState<Record<keyof FormErrors, boolean>>(INITIAL_TOUCHED)
+  const [formErrors, setFormErrors] = useState<FormErrors>(INITIAL_ERRORS)
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [feedbackStatus, setFeedbackStatus] = useState<'success' | 'error' | null>(null)
+  const [feedbackMessage, setFeedbackMessage] = useState('')
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return
+    }
+
+    try {
+      const raw = window.localStorage.getItem('trekkoSession')
+      if (!raw) {
+        setSessionState('unauthenticated')
+        return
+      }
+      const parsed = JSON.parse(raw) as SessionData
+      if (!parsed || typeof parsed.token !== 'string' || !parsed.token || !parsed.user) {
+        setSessionState('unauthenticated')
+        return
+      }
+      if (parsed.user.type !== 'guide') {
+        setSessionState('forbidden')
+        return
+      }
+      if (!parsed.user.cadastur || String(parsed.user.cadastur).trim().length < 3) {
+        setSessionState('forbidden')
+        return
+      }
+      setSession(parsed)
+      setSessionState('ready')
+    } catch (error) {
+      console.error('Falha ao ler sessão local', error)
+      setSessionState('unauthenticated')
+    }
+  }, [])
+
+  useEffect(() => {
+    setTrailPage(1)
+  }, [trailSearch, trailStateFilter, trailCityFilter])
+
+  useEffect(() => {
+    if (sessionState !== 'ready') {
+      return
+    }
+    let isCurrent = true
+    const controller = new AbortController()
+    const timeout = window.setTimeout(async () => {
+      setIsLoadingTrails(true)
+      setTrailError(null)
+      try {
+        const params = new URLSearchParams()
+        if (trailSearch.trim()) {
+          params.append('search', trailSearch.trim())
+        }
+        if (trailStateFilter) {
+          params.append('state', trailStateFilter)
+        }
+        if (trailCityFilter.trim()) {
+          params.append('city', trailCityFilter.trim())
+        }
+        params.append('page', trailPage.toString())
+        params.append('pageSize', '8')
+        const response = await fetch(`/api/trails?${params.toString()}`, {
+          signal: controller.signal
+        })
+        if (!response.ok) {
+          throw new Error('Falha ao carregar trilhas')
+        }
+        const payload = await response.json() as {
+          data: Trail[]
+          pagination?: { totalPages?: number }
+        }
+        if (!isCurrent) {
+          return
+        }
+        setTrailResults(Array.isArray(payload.data) ? payload.data : [])
+        const total = payload.pagination?.totalPages ?? 1
+        setTrailTotalPages(total || 1)
+      } catch (error) {
+        if ((error as { name?: string }).name === 'AbortError') {
+          return
+        }
+        console.error('Erro ao buscar trilhas', error)
+        if (isCurrent) {
+          setTrailError('Não foi possível carregar as trilhas no momento.')
+          setTrailResults([])
+          setTrailTotalPages(1)
+        }
+      } finally {
+        if (isCurrent) {
+          setIsLoadingTrails(false)
+        }
+      }
+    }, 280)
+
+    return () => {
+      isCurrent = false
+      window.clearTimeout(timeout)
+      controller.abort()
+    }
+  }, [sessionState, trailSearch, trailStateFilter, trailCityFilter, trailPage])
+
+  const today = useMemo(() => {
+    const now = new Date()
+    return new Date(now.getFullYear(), now.getMonth(), now.getDate())
+  }, [])
+
+  useEffect(() => {
+    const errors: FormErrors = { ...INITIAL_ERRORS }
+
+    if (!selectedTrail) {
+      errors.trail = 'Selecione uma trilha cadastrada.'
+    }
+
+    const parsedStart = startDate ? parseBrazilianDate(startDate) : null
+    const parsedEnd = endDate ? parseBrazilianDate(endDate) : null
+
+    if (!startDate) {
+      errors.startDate = 'Informe a data inicial.'
+    } else if (!parsedStart) {
+      errors.startDate = 'Data inválida. Use o formato dd/mm/aaaa.'
+    } else if (normalizeToStartOfDay(parsedStart) < today) {
+      errors.startDate = 'A data inicial deve ser igual ou posterior a hoje.'
+    }
+
+    if (!endDate) {
+      errors.endDate = 'Informe a data final.'
+    } else if (!parsedEnd) {
+      errors.endDate = 'Data inválida. Use o formato dd/mm/aaaa.'
+    } else if (parsedStart && normalizeToStartOfDay(parsedEnd) < normalizeToStartOfDay(parsedStart)) {
+      errors.endDate = 'A data final deve ser igual ou posterior à data inicial.'
+    }
+
+    const priceValue = parseCurrency(price)
+    if (!price) {
+      errors.price = 'Informe o preço por pessoa.'
+    } else if (!Number.isFinite(priceValue) || priceValue <= 0) {
+      errors.price = 'Valor inválido. Utilize apenas números.'
+    }
+
+    const maxValue = maxPeople ? Number.parseInt(maxPeople, 10) : Number.NaN
+    if (!maxPeople) {
+      errors.maxPeople = 'Informe o número máximo de pessoas.'
+    } else if (!Number.isFinite(maxValue) || maxValue <= 0) {
+      errors.maxPeople = 'Informe um número inteiro maior que zero.'
+    }
+
+    if (!description.trim()) {
+      errors.description = 'Descreva sua expedição.'
+    } else if (description.trim().length < 50) {
+      errors.description = 'A descrição deve ter pelo menos 50 caracteres.'
+    }
+
+    if (imageUploadError) {
+      errors.images = imageUploadError
+    }
+
+    setFormErrors(errors)
+  }, [selectedTrail, startDate, endDate, price, maxPeople, description, imageUploadError, today])
+
+  const isFormValid = useMemo(() => Object.values(formErrors).every(error => !error), [formErrors])
+
+  const handleTrailSelection = useCallback((trail: Trail) => {
+    setSelectedTrail(trail)
+    setTouched(prev => ({ ...prev, trail: true }))
+  }, [])
+
+  const handleImageChange = useCallback((event: FormEvent<HTMLInputElement>) => {
+    const input = event.currentTarget
+    const files = input.files
+    setTouched(prev => ({ ...prev, images: true }))
+    setImageUploadError(null)
+    if (!files || files.length === 0) {
+      return
+    }
+
+    const newFiles = Array.from(files)
+    if (uploadedImages.length + newFiles.length > MAX_IMAGES) {
+      setImageUploadError('Você pode enviar até 5 imagens.')
+      input.value = ''
+      return
+    }
+
+    const invalidType = newFiles.find(file => !ACCEPTED_IMAGE_TYPES.includes(file.type))
+    if (invalidType) {
+      setImageUploadError('Somente imagens JPG, PNG ou WEBP são permitidas.')
+      input.value = ''
+      return
+    }
+
+    const tooLarge = newFiles.find(file => file.size > MAX_IMAGE_SIZE_BYTES)
+    if (tooLarge) {
+      setImageUploadError('Cada imagem deve ter no máximo 5MB.')
+      input.value = ''
+      return
+    }
+
+    Promise.all(newFiles.map(file => new Promise<string>((resolve, reject) => {
+      const reader = new FileReader()
+      reader.onload = () => resolve(reader.result as string)
+      reader.onerror = () => reject(new Error('Falha ao ler arquivo'))
+      reader.readAsDataURL(file)
+    }))).then(results => {
+      const imagesToAdd = newFiles.map((file, index) => ({
+        name: file.name,
+        size: file.size,
+        dataUrl: results[index]
+      }))
+      setUploadedImages(prev => [...prev, ...imagesToAdd])
+      setImageUploadError(null)
+    }).catch(error => {
+      console.error('Erro ao processar imagens', error)
+      setImageUploadError('Não foi possível processar as imagens selecionadas.')
+    }).finally(() => {
+      input.value = ''
+    })
+  }, [uploadedImages.length])
+
+  const removeImage = useCallback((index: number) => {
+    setUploadedImages(prev => prev.filter((_, idx) => idx !== index))
+    setTouched(prev => ({ ...prev, images: true }))
+    setImageUploadError(null)
+  }, [])
+
+  const handleSubmit = useCallback(async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    setTouched({ ...ALL_TOUCHED })
+    setFeedbackStatus(null)
+    setFeedbackMessage('')
+
+    if (!isFormValid || !session || sessionState !== 'ready' || !selectedTrail) {
+      return
+    }
+
+    const parsedStart = parseBrazilianDate(startDate)
+    const parsedEnd = parseBrazilianDate(endDate)
+    if (!parsedStart || !parsedEnd) {
+      return
+    }
+
+    setIsSubmitting(true)
+    try {
+      const payload = {
+        trailId: selectedTrail.id,
+        trailName: selectedTrail.name,
+        trailState: selectedTrail.state,
+        trailCity: selectedTrail.city,
+        trailPark: selectedTrail.park,
+        startDate: toISODateString(parsedStart),
+        endDate: toISODateString(parsedEnd),
+        pricePerPerson: parseCurrency(price),
+        maxPeople,
+        description: description.trim(),
+        images: uploadedImages.map(image => image.dataUrl)
+      }
+
+      const response = await fetch('/api/expeditions', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${session.token}`
+        },
+        body: JSON.stringify(payload)
+      })
+
+      if (!response.ok) {
+        const data = await response.json().catch(() => ({})) as { message?: string }
+        const message = data?.message || 'Erro ao salvar expedição. Tente novamente mais tarde.'
+        setFeedbackStatus('error')
+        setFeedbackMessage(message)
+        return
+      }
+
+      setFeedbackStatus('success')
+      setFeedbackMessage('Expedição criada com sucesso!')
+      setTimeout(() => {
+        window.location.href = '/guia_painel.html#expedicoes'
+      }, 1600)
+    } catch (error) {
+      console.error('Falha ao criar expedição', error)
+      setFeedbackStatus('error')
+      setFeedbackMessage('Erro ao salvar expedição. Tente novamente mais tarde.')
+    } finally {
+      setIsSubmitting(false)
+    }
+  }, [description, endDate, isFormValid, maxPeople, price, session, sessionState, selectedTrail, startDate, uploadedImages])
+
+  const renderStatusCard = () => {
+    if (sessionState === 'loading') {
+      return (
+        <div className={styles.statusCard}>
+          <p className={styles.loadingMessage}>Carregando informações da sua conta...</p>
+        </div>
+      )
+    }
+
+    if (sessionState === 'unauthenticated') {
+      return (
+        <div className={styles.statusCard}>
+          <h1 className={styles.statusTitle}>Entre como guia para criar expedições</h1>
+          <p className={styles.statusDescription}>
+            Você precisa estar autenticado com um perfil de guia para acessar esta página. Faça login ou cadastre-se como guia para começar a publicar expedições.
+          </p>
+          <div className={styles.statusActions}>
+            <a className={`${styles.secondaryButton}`} href="/entrar.html">Entrar</a>
+            <a className={styles.submitButton} href="/cadastrar_guia.html">Quero ser guia</a>
+          </div>
+        </div>
+      )
+    }
+
+    if (sessionState === 'forbidden') {
+      return (
+        <div className={styles.statusCard}>
+          <h1 className={styles.statusTitle}>Verifique seu cadastro de guia</h1>
+          <p className={styles.statusDescription}>
+            Apenas guias com cadastro CADASTUR válido podem criar expedições. Atualize seus dados ou envie sua documentação para liberar este recurso.
+          </p>
+          <div className={styles.statusActions}>
+            <a className={styles.secondaryButton} href="/guia_painel.html">Ir para o painel do guia</a>
+            <a className={styles.submitButton} href="/ajuda.html">Preciso de ajuda</a>
+          </div>
+        </div>
+      )
+    }
+
+    return null
+  }
+
+  if (sessionState !== 'ready' || !session) {
+    return (
+      <div className={styles.page}>
+        <Head>
+          <title>Criar Expedição • Trekko Brasil</title>
+          <link rel="preconnect" href="https://fonts.googleapis.com" />
+          <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
+          <link
+            href="https://fonts.googleapis.com/css2?family=Sora:wght@400;600;700&family=Inter:wght@400;500;600;700&display=swap"
+            rel="stylesheet"
+          />
+        </Head>
+        <div className={styles.wrapper}>{renderStatusCard()}</div>
+      </div>
+    )
+  }
+
+  return (
+    <div className={styles.page}>
+      <Head>
+        <title>Criar Expedição • Trekko Brasil</title>
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
+        <link
+          href="https://fonts.googleapis.com/css2?family=Sora:wght@400;600;700&family=Inter:wght@400;500;600;700&display=swap"
+          rel="stylesheet"
+        />
+      </Head>
+      <div className={styles.wrapper}>
+        <div className={styles.card}>
+          <header className={styles.header}>
+            <span className={styles.badge}>Guia autenticado</span>
+            <h1 className={styles.title}>Criar Expedição</h1>
+            <p className={styles.subtitle}>
+              Publique uma nova expedição selecionando a trilha, definindo datas, preço e a capacidade máxima. Todos os campos são obrigatórios para garantir que os trekkers recebam informações completas.
+            </p>
+          </header>
+          <form className={styles.form} onSubmit={handleSubmit}>
+            <section className={styles.section}>
+              <h2 className={styles.sectionTitle}>Trilha</h2>
+              <div className={styles.trailPicker}>
+                <div className={styles.trailControls}>
+                  <div className={styles.field}>
+                    <label className={styles.label} htmlFor="trailSearch">
+                      Buscar por nome, estado ou parque
+                    </label>
+                    <input
+                      id="trailSearch"
+                      className={styles.input}
+                      type="text"
+                      placeholder="Digite parte do nome da trilha"
+                      value={trailSearch}
+                      onChange={event => setTrailSearch(event.target.value)}
+                    />
+                  </div>
+                  <div className={styles.field}>
+                    <label className={styles.label} htmlFor="trailState">
+                      Estado
+                    </label>
+                    <select
+                      id="trailState"
+                      className={styles.select}
+                      value={trailStateFilter}
+                      onChange={event => setTrailStateFilter(event.target.value)}
+                    >
+                      <option value="">Todos os estados</option>
+                      {['AC','AL','AP','AM','BA','CE','DF','ES','GO','MA','MT','MS','MG','PA','PB','PR','PE','PI','RJ','RN','RS','RO','RR','SC','SP','SE','TO'].map(uf => (
+                        <option key={uf} value={uf}>{uf}</option>
+                      ))}
+                    </select>
+                  </div>
+                  <div className={styles.field}>
+                    <label className={styles.label} htmlFor="trailCity">
+                      Cidade
+                    </label>
+                    <input
+                      id="trailCity"
+                      className={styles.input}
+                      type="text"
+                      placeholder="Cidade ou região"
+                      value={trailCityFilter}
+                      onChange={event => setTrailCityFilter(event.target.value)}
+                    />
+                  </div>
+                </div>
+                <div className={styles.trailResults}>
+                  {isLoadingTrails ? (
+                    <div className={styles.loadingMessage} style={{ padding: '1rem' }}>
+                      Carregando trilhas...
+                    </div>
+                  ) : trailError ? (
+                    <div className={styles.error} style={{ padding: '1rem' }}>{trailError}</div>
+                  ) : trailResults.length === 0 ? (
+                    <div className={styles.helper} style={{ padding: '1rem' }}>
+                      Nenhuma trilha encontrada com os filtros atuais.
+                    </div>
+                  ) : (
+                    <ul className={styles.trailList}>
+                      {trailResults.map(trail => {
+                        const isSelected = selectedTrail?.id === trail.id
+                        return (
+                          <li key={trail.id} className={styles.trailItem}>
+                            <button
+                              type="button"
+                              className={`${styles.trailButton} ${isSelected ? styles.trailButtonSelected : ''}`}
+                              onClick={() => handleTrailSelection(trail)}
+                            >
+                              <span className={styles.trailName}>{trail.name}</span>
+                              {buildTrailLocation(trail) && (
+                                <span className={styles.trailMeta}>{buildTrailLocation(trail)}</span>
+                              )}
+                            </button>
+                          </li>
+                        )
+                      })}
+                    </ul>
+                  )}
+                  <div className={styles.pagination}>
+                    <button
+                      type="button"
+                      onClick={() => setTrailPage(page => Math.max(1, page - 1))}
+                      disabled={trailPage <= 1}
+                    >
+                      Anterior
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => setTrailPage(page => (page < trailTotalPages ? page + 1 : page))}
+                      disabled={trailPage >= trailTotalPages}
+                    >
+                      Próxima
+                    </button>
+                  </div>
+                </div>
+                {selectedTrail && (
+                  <div className={styles.selectedTrail}>
+                    <strong>{selectedTrail.name}</strong>
+                    <span>{buildTrailLocation(selectedTrail) || 'Localização não informada'}</span>
+                  </div>
+                )}
+                {touched.trail && formErrors.trail && (
+                  <span className={styles.error}>{formErrors.trail}</span>
+                )}
+              </div>
+            </section>
+
+            <section className={styles.section}>
+              <h2 className={styles.sectionTitle}>Datas da expedição</h2>
+              <div className={styles.trailControls}>
+                <div className={styles.field}>
+                  <div className={styles.labelRow}>
+                    <label className={styles.label} htmlFor="startDate">
+                      Data inicial <span className={styles.required}>*</span>
+                    </label>
+                  </div>
+                  <input
+                    id="startDate"
+                    className={styles.input}
+                    type="text"
+                    placeholder="dd/mm/aaaa"
+                    value={startDate}
+                    onChange={event => setStartDate(formatDateInput(event.target.value))}
+                    onBlur={() => setTouched(prev => ({ ...prev, startDate: true }))}
+                  />
+                  {touched.startDate && formErrors.startDate && (
+                    <span className={styles.error}>{formErrors.startDate}</span>
+                  )}
+                </div>
+                <div className={styles.field}>
+                  <div className={styles.labelRow}>
+                    <label className={styles.label} htmlFor="endDate">
+                      Data final <span className={styles.required}>*</span>
+                    </label>
+                  </div>
+                  <input
+                    id="endDate"
+                    className={styles.input}
+                    type="text"
+                    placeholder="dd/mm/aaaa"
+                    value={endDate}
+                    onChange={event => setEndDate(formatDateInput(event.target.value))}
+                    onBlur={() => setTouched(prev => ({ ...prev, endDate: true }))}
+                  />
+                  {touched.endDate && formErrors.endDate && (
+                    <span className={styles.error}>{formErrors.endDate}</span>
+                  )}
+                </div>
+              </div>
+            </section>
+
+            <section className={styles.section}>
+              <h2 className={styles.sectionTitle}>Detalhes da expedição</h2>
+              <div className={styles.trailControls}>
+                <div className={styles.field}>
+                  <div className={styles.labelRow}>
+                    <label className={styles.label} htmlFor="price">
+                      Preço por pessoa (R$) <span className={styles.required}>*</span>
+                    </label>
+                  </div>
+                  <input
+                    id="price"
+                    className={styles.input}
+                    type="text"
+                    inputMode="decimal"
+                    placeholder="0,00"
+                    value={price}
+                    onChange={event => setPrice(formatCurrencyInput(event.target.value))}
+                    onBlur={() => setTouched(prev => ({ ...prev, price: true }))}
+                  />
+                  {touched.price && formErrors.price && (
+                    <span className={styles.error}>{formErrors.price}</span>
+                  )}
+                </div>
+                <div className={styles.field}>
+                  <div className={styles.labelRow}>
+                    <label className={styles.label} htmlFor="maxPeople">
+                      Quantidade máxima de pessoas <span className={styles.required}>*</span>
+                    </label>
+                  </div>
+                  <input
+                    id="maxPeople"
+                    className={styles.input}
+                    type="number"
+                    min={1}
+                    step={1}
+                    placeholder="Ex: 12"
+                    value={maxPeople}
+                    onChange={event => setMaxPeople(event.target.value.replace(/[^0-9]/g, ''))}
+                    onBlur={() => setTouched(prev => ({ ...prev, maxPeople: true }))}
+                  />
+                  {touched.maxPeople && formErrors.maxPeople && (
+                    <span className={styles.error}>{formErrors.maxPeople}</span>
+                  )}
+                </div>
+              </div>
+              <div className={styles.field}>
+                <div className={styles.labelRow}>
+                  <label className={styles.label} htmlFor="description">
+                    Descrição da expedição <span className={styles.required}>*</span>
+                  </label>
+                </div>
+                <textarea
+                  id="description"
+                  className={styles.textarea}
+                  value={description}
+                  onChange={event => setDescription(event.target.value)}
+                  onBlur={() => setTouched(prev => ({ ...prev, description: true }))}
+                  placeholder="Compartilhe os detalhes da expedição: roteiro, tempo estimado, diferenciais, equipamentos, etc."
+                />
+                <span className={styles.charCount}>{description.trim().length} / mínimo 50 caracteres</span>
+                {touched.description && formErrors.description && (
+                  <span className={styles.error}>{formErrors.description}</span>
+                )}
+              </div>
+            </section>
+
+            <section className={styles.section}>
+              <h2 className={styles.sectionTitle}>Fotos da expedição</h2>
+              <div className={styles.imagesInput}>
+                <div className={styles.field}>
+                  <label className={styles.label} htmlFor="images">
+                    Adicione até 5 fotos (JPG, PNG ou WEBP)
+                  </label>
+                  <input
+                    id="images"
+                    className={styles.input}
+                    type="file"
+                    accept={ACCEPTED_IMAGE_TYPES.join(',')}
+                    multiple
+                    onChange={handleImageChange}
+                    onBlur={() => setTouched(prev => ({ ...prev, images: true }))}
+                  />
+                  {touched.images && formErrors.images && (
+                    <span className={styles.error}>{formErrors.images}</span>
+                  )}
+                  <span className={styles.helper}>As imagens ajudam trekkers a visualizarem a experiência. Tamanho máximo por arquivo: 5MB.</span>
+                </div>
+                {uploadedImages.length > 0 && (
+                  <div className={styles.imagesPreview}>
+                    {uploadedImages.map((image, index) => (
+                      <div key={`${image.name}-${index}`} className={styles.imageThumb}>
+                        <img src={image.dataUrl} alt={`Pré-visualização ${index + 1}`} />
+                        <button
+                          type="button"
+                          className={styles.removeImageButton}
+                          onClick={() => removeImage(index)}
+                          aria-label="Remover imagem"
+                        >
+                          ×
+                        </button>
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </div>
+            </section>
+
+            <div className={styles.submitBar}>
+              {feedbackStatus && (
+                <span
+                  className={`${styles.feedbackMessage} ${feedbackStatus === 'success' ? styles.success : styles.errorMessage}`}
+                >
+                  {feedbackMessage}
+                </span>
+              )}
+              <div className={styles.submitActions}>
+                <button
+                  type="submit"
+                  className={styles.submitButton}
+                  disabled={!isFormValid || isSubmitting}
+                >
+                  {isSubmitting ? 'Salvando...' : 'Criar Expedição'}
+                </button>
+                <a className={styles.secondaryButton} href="/guia_painel.html#expedicoes">
+                  Cancelar
+                </a>
+              </div>
+            </div>
+          </form>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -112,6 +112,7 @@ model Expedition {
   endDate         DateTime
   pricePerPerson  Decimal           @db.Decimal(10, 2)
   maxPeople       Int
+  images          String[]          @default([])
   status          ExpeditionStatus  @default(ACTIVE)
   createdAt       DateTime          @default(now())
   updatedAt       DateTime          @updatedAt

--- a/styles/CreateExpedition.module.css
+++ b/styles/CreateExpedition.module.css
@@ -1,0 +1,409 @@
+.page {
+  min-height: 100vh;
+  background: linear-gradient(180deg, #f5f9f7 0%, #eef3f0 100%);
+  padding-bottom: 4rem;
+}
+
+.wrapper {
+  max-width: 1080px;
+  margin: 0 auto;
+  padding: 2.5rem 1.5rem 0;
+}
+
+.card {
+  background: #ffffff;
+  border-radius: 20px;
+  box-shadow: 0 16px 40px rgba(26, 77, 46, 0.12);
+  padding: 2.5rem 2.75rem;
+}
+
+.header {
+  margin-bottom: 2.5rem;
+}
+
+.title {
+  font-family: 'Sora', sans-serif;
+  font-size: 2rem;
+  color: #1a4d2e;
+  margin: 0 0 0.75rem;
+}
+
+.subtitle {
+  color: #4a5a58;
+  font-size: 1.05rem;
+  line-height: 1.6;
+  max-width: 760px;
+}
+
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.section {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.sectionTitle {
+  font-family: 'Sora', sans-serif;
+  color: #1a4d2e;
+  font-size: 1.25rem;
+  margin-bottom: 0.5rem;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+}
+
+.labelRow {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  margin-bottom: 0.4rem;
+}
+
+.label {
+  font-weight: 600;
+  color: #1f2a2e;
+  font-size: 0.95rem;
+}
+
+.required {
+  color: #c62828;
+  margin-left: 0.25rem;
+  font-weight: 600;
+}
+
+.input,
+.textarea,
+.select {
+  border: 1px solid #cfd8dc;
+  border-radius: 10px;
+  padding: 0.75rem 0.85rem;
+  font-size: 1rem;
+  background: #ffffff;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.input:focus,
+.textarea:focus,
+.select:focus {
+  outline: none;
+  border-color: #1a4d2e;
+  box-shadow: 0 0 0 3px rgba(26, 77, 46, 0.15);
+}
+
+.textarea {
+  resize: vertical;
+  min-height: 150px;
+  line-height: 1.6;
+}
+
+.helper {
+  color: #6b7c7a;
+  font-size: 0.85rem;
+  margin-top: 0.35rem;
+}
+
+.charCount {
+  font-size: 0.8rem;
+  color: #6b7c7a;
+  margin-top: 0.2rem;
+  text-align: right;
+}
+
+.error {
+  color: #c62828;
+  font-size: 0.85rem;
+  margin-top: 0.35rem;
+}
+
+.trailPicker {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.trailControls {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 1rem;
+}
+
+.trailResults {
+  border: 1px solid #d9e3de;
+  border-radius: 12px;
+  overflow: hidden;
+  background: #fafdfb;
+}
+
+.trailList {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  max-height: 260px;
+  overflow-y: auto;
+}
+
+.trailItem {
+  border-bottom: 1px solid rgba(26, 77, 46, 0.08);
+}
+
+.trailItem:last-child {
+  border-bottom: none;
+}
+
+.trailButton {
+  width: 100%;
+  text-align: left;
+  background: none;
+  border: none;
+  padding: 0.9rem 1rem;
+  cursor: pointer;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  transition: background 0.2s ease, border-left 0.2s ease;
+}
+
+.trailButton:hover,
+.trailButton:focus-visible {
+  background: rgba(26, 77, 46, 0.08);
+  outline: none;
+}
+
+.trailButtonSelected {
+  background: rgba(26, 77, 46, 0.12);
+  border-left: 4px solid #1a4d2e;
+}
+
+.trailName {
+  font-weight: 600;
+  color: #1f2a2e;
+}
+
+.trailMeta {
+  color: #546460;
+  font-size: 0.85rem;
+}
+
+.selectedTrail {
+  border: 1px solid rgba(26, 77, 46, 0.25);
+  background: rgba(26, 77, 46, 0.08);
+  padding: 1rem 1.2rem;
+  border-radius: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.pagination {
+  display: flex;
+  gap: 0.5rem;
+  justify-content: flex-end;
+  padding: 0.75rem 1rem 1rem;
+}
+
+.pagination button {
+  border: 1px solid #1a4d2e;
+  background: #ffffff;
+  color: #1a4d2e;
+  border-radius: 999px;
+  padding: 0.4rem 0.85rem;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.pagination button:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.pagination button:not(:disabled):hover {
+  background: #1a4d2e;
+  color: #ffffff;
+}
+
+.imagesInput {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.imagesPreview {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 1rem;
+}
+
+.imageThumb {
+  position: relative;
+  border-radius: 12px;
+  overflow: hidden;
+  background: #f0f4f2;
+  border: 1px solid rgba(26, 77, 46, 0.12);
+}
+
+.imageThumb img {
+  width: 100%;
+  height: 130px;
+  object-fit: cover;
+  display: block;
+}
+
+.removeImageButton {
+  position: absolute;
+  top: 6px;
+  right: 6px;
+  background: rgba(198, 40, 40, 0.9);
+  color: #ffffff;
+  border: none;
+  border-radius: 999px;
+  width: 28px;
+  height: 28px;
+  cursor: pointer;
+  font-size: 0.9rem;
+  line-height: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.submitBar {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  align-items: flex-start;
+}
+
+.submitActions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.submitButton {
+  background: #1a4d2e;
+  color: #ffffff;
+  border: none;
+  border-radius: 999px;
+  padding: 0.9rem 1.8rem;
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.submitButton:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+  transform: none;
+  box-shadow: none;
+}
+
+.submitButton:not(:disabled):hover {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 20px rgba(26, 77, 46, 0.2);
+}
+
+.secondaryButton {
+  border: 1px solid #1a4d2e;
+  color: #1a4d2e;
+  background: #ffffff;
+  border-radius: 999px;
+  padding: 0.85rem 1.6rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.feedbackMessage {
+  font-size: 0.95rem;
+  font-weight: 500;
+}
+
+.success {
+  color: #1a7f37;
+}
+
+.errorMessage {
+  color: #c62828;
+}
+
+.statusCard {
+  max-width: 680px;
+  margin: 4rem auto;
+  background: #ffffff;
+  padding: 2.5rem 2rem;
+  border-radius: 18px;
+  box-shadow: 0 12px 28px rgba(26, 77, 46, 0.1);
+  text-align: center;
+}
+
+.statusTitle {
+  font-family: 'Sora', sans-serif;
+  color: #1a4d2e;
+  font-size: 1.6rem;
+  margin-bottom: 1rem;
+}
+
+.statusDescription {
+  color: #4f5f5c;
+  font-size: 1rem;
+  line-height: 1.6;
+  margin-bottom: 1.5rem;
+}
+
+.statusActions {
+  display: flex;
+  justify-content: center;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.loadingMessage {
+  color: #4f5f5c;
+  font-size: 1rem;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  background: rgba(26, 77, 46, 0.12);
+  color: #1a4d2e;
+  padding: 0.3rem 0.75rem;
+  border-radius: 999px;
+  font-size: 0.8rem;
+  font-weight: 600;
+}
+
+@media (max-width: 900px) {
+  .card {
+    padding: 2rem 1.5rem;
+  }
+}
+
+@media (max-width: 640px) {
+  .wrapper {
+    padding: 2rem 1rem 0;
+  }
+
+  .card {
+    border-radius: 16px;
+  }
+
+  .submitActions {
+    width: 100%;
+  }
+
+  .submitButton,
+  .secondaryButton {
+    width: 100%;
+    justify-content: center;
+    text-align: center;
+  }
+}

--- a/types/css.d.ts
+++ b/types/css.d.ts
@@ -1,0 +1,9 @@
+declare module '*.module.css' {
+  const classes: { readonly [key: string]: string }
+  export default classes
+}
+
+declare module '*.css' {
+  const classes: { readonly [key: string]: string }
+  export default classes
+}


### PR DESCRIPTION
## Summary
- add a dedicated Next.js page for guias to criar expedições with client-side validation, image uploads and dynamic trail lookup
- expose a GET /api/trails endpoint and extend /api/expeditions to accept dd/mm/aaaa dates, validate inputs and persist expedition images
- surface stored images in expedition responses, update the schema and adjust the Expedicoes CTA to link to the new flow

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68de85727ae88324be230d1166fbf2e8