### PR TITLE
Broaden guide CTA visibility detection

### DIFF
--- a/expedicoes.html
+++ b/expedicoes.html
@@ -60,9 +60,14 @@
     </div>
 
     <main class="container" style="padding-top:2rem;">
-        <h1 style="font-family:'Sora',sans-serif;color:var(--color-primary);margin-bottom:1.5rem;">Expedições</h1>
-        <div id="guideExpeditionActions" class="guide-expedition-actions">
-            <a href="/criar-expedicao" class="btn btn-primary">Criar Expedição</a>
+        <div class="expeditions-header">
+            <h1 style="font-family:'Sora',sans-serif;color:var(--color-primary);margin:0;">Expedições</h1>
+            <div id="guideExpeditionActions" class="guide-expedition-actions" aria-hidden="true">
+                <a href="criar-expedicao.html" class="btn btn-primary">
+                    <i class="fas fa-plus" aria-hidden="true"></i>
+                    <span>Criar Expedição</span>
+                </a>
+            </div>
         </div>
         <div class="expeditions-filters" style="display:flex;flex-wrap:wrap;gap:1rem;margin-bottom:1.5rem;">
             <input type="text" id="expSearchFilter" placeholder="Buscar expedição ou trilha" style="flex:1 1 200px;padding:0.6rem;border:1px solid #ccc;border-radius:4px;" />

--- a/scripts.js
+++ b/scripts.js
@@ -900,10 +900,34 @@ async function setupNavigation() {
 function updateGuideExpeditionActionsForUser(user) {
   const guideActions = document.getElementById('guideExpeditionActions');
   if (!guideActions) return;
-  if (user && user.type === 'guide') {
+
+  const rawCadastur = user
+    ? user.cadastur
+      ?? user.cadasturNumber
+      ?? user.numero_cadastur
+      ?? user.numeroCadastur
+      ?? user.cadastur_number
+      ?? user.cadasturNumero
+      ?? user.cadasturId
+      ?? user.cadasturID
+    : null;
+  const cadasturText = typeof rawCadastur === 'number'
+    ? rawCadastur.toString()
+    : typeof rawCadastur === 'string'
+      ? rawCadastur
+      : '';
+  const hasValidCadastur = cadasturText.trim().length > 0;
+
+  const role = typeof user?.role === 'string' ? user.role.toLowerCase() : '';
+  const type = typeof user?.type === 'string' ? user.type.toLowerCase() : '';
+  const isGuide = role === 'guide' || role === 'guia' || type === 'guide' || type === 'guia';
+
+  if (user && isGuide && hasValidCadastur) {
     guideActions.classList.add('is-visible');
+    guideActions.removeAttribute('aria-hidden');
   } else {
     guideActions.classList.remove('is-visible');
+    guideActions.setAttribute('aria-hidden', 'true');
   }
 }
 

--- a/styles.css
+++ b/styles.css
@@ -2188,10 +2188,18 @@ footer {
   color: #c62828;
 }
 
+
+.expeditions-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1.5rem;
+  margin-bottom: 1.5rem;
+}
+
 .guide-expedition-actions {
   display: none;
   justify-content: flex-end;
-  margin-bottom: 1.5rem;
 }
 
 .expeditions-tabs {
@@ -2248,16 +2256,30 @@ footer {
 
 .guide-expedition-actions .btn {
   align-self: flex-start;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.guide-expedition-actions .btn i {
+  font-size: 0.85rem;
 }
 
 @media (max-width: 640px) {
+  .expeditions-header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
   .guide-expedition-actions {
     justify-content: flex-start;
+    width: 100%;
   }
 
   .guide-expedition-actions .btn {
     width: 100%;
     text-align: center;
+    justify-content: center;
   }
 }
 


### PR DESCRIPTION
## Summary
- ensure the expeditions CTA honours additional user role aliases and CADASTUR field names when deciding visibility
- expose the create-expedition action to assistive tech only when a qualified guide is signed in by toggling aria-hidden along with the visibility class

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dea1bb32e48324a933f0f71beb9a43