### PR TITLE
Add site HTML files at repository root

### DIFF
--- a/home_page_spec.html
+++ b/home_page_spec.html
@@ -1,0 +1,471 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="utf-8" />
+  <title>TreKKo Home Page Functional Specification</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <style>
+    :root {
+      color-scheme: light dark;
+      font-family: "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+      line-height: 1.6;
+      background-color: #f5f5f5;
+      color: #1e1e1e;
+    }
+
+    body {
+      margin: 0;
+      padding: 2.5rem;
+      max-width: 960px;
+      margin-left: auto;
+      margin-right: auto;
+      background-color: #ffffff;
+      box-shadow: 0 20px 40px rgba(0, 0, 0, 0.1);
+      border-radius: 16px;
+    }
+
+    h1,
+    h2,
+    h3,
+    h4 {
+      color: #1e3a5f;
+      margin-top: 2.25rem;
+      margin-bottom: 1rem;
+      font-weight: 700;
+    }
+
+    h1 {
+      font-size: 2.5rem;
+    }
+
+    h2 {
+      font-size: 1.9rem;
+    }
+
+    h3 {
+      font-size: 1.5rem;
+      color: #2d6a4f;
+    }
+
+    p {
+      margin: 0 0 1rem 0;
+    }
+
+    ul {
+      list-style: disc inside;
+      margin: 0 0 1.4rem 0;
+      padding: 0;
+    }
+
+    li {
+      margin-bottom: 0.4rem;
+    }
+
+    .palette {
+      display: flex;
+      gap: 0.75rem;
+      flex-wrap: wrap;
+      margin-bottom: 1.4rem;
+    }
+
+    .swatch {
+      width: 110px;
+      height: 110px;
+      border-radius: 12px;
+      box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.08);
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      color: #ffffff;
+      font-weight: 600;
+    }
+
+    .swatch span {
+      font-size: 0.8rem;
+      opacity: 0.85;
+      margin-top: 0.5rem;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+    }
+
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      margin-bottom: 1.8rem;
+      font-size: 0.95rem;
+    }
+
+    th,
+    td {
+      border: 1px solid rgba(30, 58, 95, 0.15);
+      padding: 0.75rem 1rem;
+      text-align: left;
+      vertical-align: top;
+    }
+
+    th {
+      background-color: rgba(45, 106, 79, 0.1);
+      font-weight: 700;
+    }
+
+    .tag-group {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.5rem;
+      margin-bottom: 1.6rem;
+    }
+
+    .tag {
+      background-color: rgba(30, 58, 95, 0.08);
+      color: #1e3a5f;
+      padding: 0.35rem 0.75rem;
+      border-radius: 999px;
+      font-size: 0.85rem;
+      font-weight: 600;
+      letter-spacing: 0.03em;
+    }
+
+    .section-intro {
+      background: linear-gradient(135deg, rgba(45, 106, 79, 0.1), rgba(30, 58, 95, 0.15));
+      padding: 1.5rem;
+      border-radius: 14px;
+      margin-bottom: 2rem;
+      color: #1e3a5f;
+    }
+
+    .section-intro h2 {
+      margin-top: 0;
+      color: inherit;
+    }
+
+    .grid-specs {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+      gap: 1.25rem;
+      margin-bottom: 2rem;
+    }
+
+    .grid-card {
+      background-color: rgba(231, 217, 192, 0.35);
+      border-radius: 14px;
+      padding: 1.25rem;
+      border: 1px solid rgba(124, 75, 42, 0.2);
+    }
+
+    .grid-card h4 {
+      margin-top: 0;
+      margin-bottom: 0.75rem;
+      color: #7c4b2a;
+    }
+
+    .steps {
+      counter-reset: step;
+    }
+
+    .steps li {
+      position: relative;
+      padding-left: 3.25rem;
+      margin-bottom: 1.5rem;
+    }
+
+    .steps li::before {
+      counter-increment: step;
+      content: counter(step);
+      position: absolute;
+      left: 0;
+      top: 0.1rem;
+      width: 2.4rem;
+      height: 2.4rem;
+      border-radius: 50%;
+      background: linear-gradient(135deg, #2d6a4f, #1e3a5f);
+      color: #ffffff;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-weight: 700;
+    }
+
+    .footer {
+      margin-top: 3rem;
+      padding-top: 1.5rem;
+      border-top: 1px solid rgba(30, 58, 95, 0.2);
+      font-size: 0.9rem;
+      color: rgba(51, 51, 51, 0.8);
+    }
+
+    @media (max-width: 720px) {
+      body {
+        padding: 1.5rem;
+      }
+
+      h1 {
+        font-size: 2rem;
+      }
+
+      h2 {
+        font-size: 1.6rem;
+      }
+
+      h3 {
+        font-size: 1.35rem;
+      }
+
+      .swatch {
+        width: 100px;
+        height: 100px;
+      }
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>TreKKo Home Page Functional Specification</h1>
+    <p class="section-intro">
+      Documento detalhado para orientar os times de produto, design e engenharia na construção da página inicial do TreKKo,
+      enfatizando uma experiência de descoberta de trilhas e expedições, sincronização com os dados oficiais do BD_CADASTUR e
+      alinhamento com os padrões de autenticação, desempenho e observabilidade da plataforma.
+    </p>
+  </header>
+
+  <section>
+    <h2>1. Objetivos</h2>
+    <ul>
+      <li>Entregar uma landing page visualmente envolvente inspirada na experiência do Airbnb.</li>
+      <li>Exibir dados reais de trilhas, parques e expedições (sem uso de mocks).</li>
+      <li>Habilitar descoberta geoespacial com transições fluidas entre listagem e mapa.</li>
+      <li>Suportar fluxos de ativação de guias baseados no registro BD_CADASTUR.</li>
+      <li>Manter altos padrões de desempenho, acessibilidade, SEO e observabilidade.</li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>2. Layout e Arquitetura da Informação</h2>
+
+    <article>
+      <h3>2.1 Cabeçalho</h3>
+      <div class="palette" aria-label="Paleta de cores TreKKo">
+        <div class="swatch" style="background-color: #2D6A4F;">#2D6A4F<span>Verde Floresta</span></div>
+        <div class="swatch" style="background-color: #7C4B2A;">#7C4B2A<span>Marrom Terra</span></div>
+        <div class="swatch" style="background-color: #1E3A5F;">#1E3A5F<span>Azul Petróleo</span></div>
+        <div class="swatch" style="background-color: #E7D9C0; color: #333;">#E7D9C0<span>Bege</span></div>
+        <div class="swatch" style="background-color: #333333;">#333333<span>Grafite</span></div>
+      </div>
+      <ul>
+        <li><strong>Logo:</strong> aplicação da paleta TreKKo acima.</li>
+        <li><strong>Pílula de busca principal:</strong>
+          <ul>
+            <li>Placeholder: <em>Buscar por trilha, parque, cidade ou estado</em>.</li>
+            <li>Sugestões automáticas alimentadas por datasets de trilhas, parques, cidades e estados.</li>
+            <li>Botão com ícone de busca dispara submissão.</li>
+          </ul>
+        </li>
+        <li><strong>Ações à direita:</strong> Favoritos (usuários autenticados), Ajuda/FAQ e menu do usuário (Entrar, Perfil, Minhas reservas, Sair).</li>
+        <li><strong>Comportamento responsivo:</strong>
+          <ul>
+            <li>Reduzir cabeçalho e compactar busca ao rolar.</li>
+            <li>No mobile, centralizar a busca com botão flutuante para acessibilidade.</li>
+          </ul>
+        </li>
+      </ul>
+    </article>
+
+    <article>
+      <h3>2.2 Carrossel de Categorias</h3>
+      <p>Carrossel horizontal de filtros rápidos com ícones pictográficos.</p>
+      <div class="tag-group" aria-label="Categorias iniciais">
+        <span class="tag">Montanha</span>
+        <span class="tag">Cachoeira</span>
+        <span class="tag">Parques Nacionais</span>
+        <span class="tag">Pet-friendly</span>
+        <span class="tag">Multi-day</span>
+        <span class="tag">Trilhas curtas</span>
+        <span class="tag">Trilhas com camping</span>
+      </div>
+      <p>Cada seleção aplica o filtro correspondente via módulo de busca.</p>
+    </article>
+
+    <article>
+      <h3>2.3 Grade de Trilhas e Expedições</h3>
+      <div class="grid-specs">
+        <div class="grid-card">
+          <h4>Layout Responsivo</h4>
+          <ul>
+            <li>4 colunas no desktop.</li>
+            <li>2 colunas em tablets.</li>
+            <li>1 coluna em dispositivos móveis.</li>
+          </ul>
+        </div>
+        <div class="grid-card">
+          <h4>Conteúdo dos Cards</h4>
+          <ul>
+            <li>Imagem de capa com carrossel no hover (desktop) e gesto de swipe no mobile.</li>
+            <li>Nome da trilha e metadados do parque/região.</li>
+            <li>Cidade e UF.</li>
+            <li>Dificuldade, distância, ganho de elevação.</li>
+            <li>Preço da expedição (quando existir).</li>
+            <li>Avaliação média com ícone de estrela e contagem de reviews.</li>
+            <li>Badges: Pet-friendly, Guia obrigatório, Camping permitido.</li>
+          </ul>
+        </div>
+      </div>
+    </article>
+
+    <article>
+      <h3>2.4 Alternância para Mapa</h3>
+      <ul>
+        <li>Botão "Ver no mapa" transforma o layout em divisão 50/50: lista à esquerda e mapa à direita.</li>
+        <li><strong>Interações:</strong>
+          <ul>
+            <li>Pins representam trilhas/expedições filtradas na visão atual.</li>
+            <li>Selecionar um pin destaca e rola até o card associado.</li>
+            <li>Selecionar um card foca o pin correspondente no mapa.</li>
+          </ul>
+        </li>
+      </ul>
+    </article>
+
+    <article>
+      <h3>2.5 Como Funciona</h3>
+      <ul class="steps">
+        <li>Encontrar trilha ideal.</li>
+        <li>Reservar com guias certificados no CADASTUR.</li>
+        <li>Viver a experiência com segurança e sustentabilidade.</li>
+      </ul>
+    </article>
+
+    <article>
+      <h3>2.6 Destinos em Alta</h3>
+      <p>Carrossel que destaca os estados/regiões mais buscados.</p>
+      <ul>
+        <li>Exibir nome do destino.</li>
+        <li>Contagem em tempo real de trilhas disponíveis.</li>
+        <li>Imagem hero proveniente da primeira trilha daquele local.</li>
+      </ul>
+    </article>
+
+    <article>
+      <h3>2.7 Rodapé</h3>
+      <ul>
+        <li>Links: Sobre, Contato, Política de Privacidade, Termos de Uso.</li>
+        <li>Ícones de redes sociais e placeholder para botão "Baixar App".</li>
+        <li>Seletor de idioma: pt-BR (padrão) e en-US.</li>
+      </ul>
+    </article>
+  </section>
+
+  <section>
+    <h2>3. Dados e Integrações</h2>
+    <article>
+      <h3>3.1 BD_CADASTUR</h3>
+      <p>Fonte oficial para cadastro de guias.</p>
+      <table>
+        <thead>
+          <tr>
+            <th>Campo obrigatório</th>
+            <th>Descrição</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>cadastur_numero</td>
+            <td>Código de identificação CADASTUR.</td>
+          </tr>
+          <tr>
+            <td>nome_completo</td>
+            <td>Nome do guia conforme cadastro oficial.</td>
+          </tr>
+          <tr>
+            <td>uf</td>
+            <td>Unidade federativa.</td>
+          </tr>
+          <tr>
+            <td>municipio</td>
+            <td>Município associado.</td>
+          </tr>
+          <tr>
+            <td>contato_email</td>
+            <td>E-mail para contato.</td>
+          </tr>
+          <tr>
+            <td>whatsapp</td>
+            <td>Número de WhatsApp.</td>
+          </tr>
+          <tr>
+            <td>instagram</td>
+            <td>Conta do Instagram.</td>
+          </tr>
+          <tr>
+            <td>foto_url</td>
+            <td>URL da foto do guia.</td>
+          </tr>
+          <tr>
+            <td>status_cadastur</td>
+            <td>Status de validação no CADASTUR.</td>
+          </tr>
+        </tbody>
+      </table>
+      <p>Atualizado via upload de CSV pelo painel administrativo com sincronização de staging para produção.</p>
+    </article>
+
+    <article>
+      <h3>3.2 Tabelas da Plataforma</h3>
+      <ul>
+        <li><strong>users:</strong> gerencia autenticação e tipos de usuário (<em>trekker</em>, <em>guia</em>).</li>
+        <li><strong>guides:</strong> vincula usuários a entradas do BD_CADASTUR e controla status de ativação.</li>
+        <li><strong>trails</strong>, <strong>expeditions</strong>, <strong>reviews</strong>: alimentam conteúdo da home e resultados de busca.</li>
+      </ul>
+    </article>
+
+    <article>
+      <h3>3.3 Serviço de Busca</h3>
+      <ul>
+        <li>Consulta principal indexa trilhas, parques, cidades e estados.</li>
+        <li>Filtros: categoria, dificuldade, distância, ganho de elevação, pontos de água, camping, pet-friendly e obrigatoriedade de guia.</li>
+        <li>Ordenação: relevância (padrão), avaliação, distância, menor preço.</li>
+      </ul>
+    </article>
+  </section>
+
+  <section>
+    <h2>4. Autenticação e Ativação de Guias</h2>
+    <ul>
+      <li>Login com magic link (preferencial), Google OAuth e Apple OAuth.</li>
+      <li>Sessões com cookies HTTP-only, proteção CSRF, rate limiting, CAPTCHA Turnstile e timeout após 24h de inatividade.</li>
+      <li>Fluxo de ativação de guia:</li>
+    </ul>
+    <ol>
+      <li>Usuário autenticado com <code>tipo_usuario != "guia"</code> vê CTA "Ativar cadastro de guia CADASTUR".</li>
+      <li>Formulário captura número CADASTUR, nome (pré-preenchido e editável), UF e município.</li>
+      <li>Backend valida dados contra o BD_CADASTUR com correspondência case e accent insensitive.</li>
+      <li>Sucesso: cria/atualiza registro em <code>guides</code> com <code>status_platform = "pending"</code> e notifica admin.</li>
+      <li>Falha: exibe mensagens de erro contextuais e registra tentativa.</li>
+      <li>Admin revisa, altera status para <code>active</code> e promove <code>users.tipo_usuario</code>.</li>
+    </ol>
+  </section>
+
+  <section>
+    <h2>5. Desempenho, SEO e Acessibilidade</h2>
+    <ul>
+      <li>Stack: Next.js App Router com SSR e ISR.</li>
+      <li>Otimizações: CDN, lazy-loading de imagens, metadados schema.org, tags OG, sitemap e robots.txt.</li>
+      <li>Metas de Core Web Vitals: LCP &lt; 2,5s, CLS &lt; 0,1, INP &lt; 200ms.</li>
+      <li>Acessibilidade: semântica ARIA, contraste AA, navegação por teclado.</li>
+      <li>i18n: pt-BR como padrão com opção en-US.</li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>6. Observabilidade e Analytics</h2>
+    <ul>
+      <li>Eventos rastreados: <code>search_submitted</code>, <code>filter_applied</code>, <code>card_clicked</code>, <code>map_opened</code>, <code>guide_activation_opened</code>, <code>guide_activation_success</code>, <code>guide_activation_fail</code>.</li>
+      <li>Gerar alerta quando a taxa de falha de ativação de guias exceder 3%.</li>
+      <li>Logs de auditoria com IP, user agent, timestamps e resultados das tentativas de ativação.</li>
+    </ul>
+  </section>
+
+  <footer class="footer">
+    <p>TreKKo &copy; 2024 &mdash; Documento interno de especificação funcional.</p>
+  </footer>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,743 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>TreKKo — Conectando trekkers e guias oficiais</title>
+    <meta
+      name="description"
+      content="Descubra trilhas brasileiras e reserve guias credenciados CADASTUR na TreKKo."
+    />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      :root {
+        color-scheme: light dark;
+        --bg: #0b1d26;
+        --bg-muted: #122836;
+        --bg-card: rgba(18, 40, 54, 0.8);
+        --bg-card-light: rgba(255, 255, 255, 0.08);
+        --accent: #5be9b9;
+        --accent-strong: #27d3a8;
+        --text: #f5f7fa;
+        --text-muted: rgba(245, 247, 250, 0.72);
+        --border: rgba(91, 233, 185, 0.25);
+        font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
+          sans-serif;
+        background-color: var(--bg);
+        color: var(--text);
+        scroll-behavior: smooth;
+      }
+
+      *,
+      *::before,
+      *::after {
+        box-sizing: border-box;
+      }
+
+      body {
+        margin: 0;
+        min-height: 100vh;
+      }
+
+      header {
+        position: relative;
+        padding: 48px clamp(1.5rem, 5vw, 80px);
+        overflow: hidden;
+        background: linear-gradient(180deg, rgba(11, 29, 38, 0.88) 0%, #0b1d26 65%);
+        isolation: isolate;
+      }
+
+      header::before,
+      header::after {
+        content: "";
+        position: absolute;
+        inset: -40% -20% auto;
+        height: 90%;
+        background: radial-gradient(circle at top left, rgba(91, 233, 185, 0.24), transparent);
+        z-index: -1;
+      }
+
+      header::after {
+        inset: auto -25% -45% 30%;
+        height: 110%;
+        background: radial-gradient(circle at bottom right, rgba(91, 233, 185, 0.18), transparent);
+      }
+
+      nav {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        gap: 1.5rem;
+        flex-wrap: wrap;
+        margin-bottom: 72px;
+      }
+
+      .logo {
+        font-size: clamp(1.4rem, 1.4rem + 0.4vw, 1.75rem);
+        font-weight: 700;
+        letter-spacing: 0.14em;
+        text-transform: uppercase;
+        color: var(--accent);
+      }
+
+      nav ul {
+        list-style: none;
+        display: flex;
+        gap: clamp(1rem, 0.6rem + 1.4vw, 2.5rem);
+        padding: 0;
+        margin: 0;
+      }
+
+      nav a {
+        color: var(--text-muted);
+        text-decoration: none;
+        font-weight: 500;
+        letter-spacing: 0.01em;
+      }
+
+      nav a:hover,
+      nav a:focus {
+        color: var(--text);
+      }
+
+      .cta {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.65rem;
+        padding: 0.95rem 1.8rem;
+        border-radius: 999px;
+        border: 1px solid var(--accent);
+        color: #0b1d26;
+        background: var(--accent);
+        font-weight: 600;
+        text-decoration: none;
+        transition: transform 0.2s ease, box-shadow 0.2s ease;
+      }
+
+      .cta:hover,
+      .cta:focus {
+        transform: translateY(-2px);
+        box-shadow: 0 16px 30px rgba(91, 233, 185, 0.2);
+      }
+
+      .hero {
+        display: grid;
+        gap: 32px;
+        max-width: 960px;
+      }
+
+      .kicker {
+        text-transform: uppercase;
+        letter-spacing: 0.35em;
+        font-weight: 600;
+        font-size: 0.75rem;
+        color: var(--accent);
+      }
+
+      h1 {
+        font-size: clamp(2.4rem, 1rem + 4vw, 4rem);
+        margin: 0;
+        line-height: 1.15;
+      }
+
+      .hero p {
+        font-size: clamp(1rem, 0.6rem + 1vw, 1.25rem);
+        color: var(--text-muted);
+        margin: 0;
+      }
+
+      .hero-actions {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 1rem;
+        align-items: center;
+      }
+
+      .secondary-cta {
+        display: inline-flex;
+        gap: 0.6rem;
+        align-items: center;
+        color: var(--text);
+        text-decoration: none;
+        font-weight: 600;
+      }
+
+      main {
+        padding: clamp(3rem, 4vw, 5rem) clamp(1.5rem, 5vw, 6.5rem) 5rem;
+        display: grid;
+        gap: clamp(3rem, 4vw, 5rem);
+      }
+
+      section {
+        display: grid;
+        gap: 2rem;
+      }
+
+      .search-card {
+        background: var(--bg-muted);
+        border-radius: 20px;
+        padding: clamp(1.8rem, 2vw, 2.6rem);
+        box-shadow: 0 20px 60px rgba(0, 0, 0, 0.25);
+        border: 1px solid rgba(255, 255, 255, 0.04);
+        display: grid;
+        gap: 1.6rem;
+      }
+
+      .search-card h2 {
+        margin: 0;
+        font-size: 1.6rem;
+      }
+
+      .search-grid {
+        display: grid;
+        gap: 1.2rem;
+        grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+      }
+
+      label {
+        display: grid;
+        gap: 0.45rem;
+        font-size: 0.85rem;
+        color: var(--text-muted);
+      }
+
+      input,
+      select {
+        border-radius: 12px;
+        border: 1px solid var(--border);
+        padding: 0.85rem 1rem;
+        background: rgba(255, 255, 255, 0.04);
+        color: var(--text);
+        font-size: 1rem;
+      }
+
+      input::placeholder {
+        color: rgba(245, 247, 250, 0.55);
+      }
+
+      .stats-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+        gap: 1.8rem;
+      }
+
+      .stat-card {
+        padding: 1.8rem 1.4rem;
+        border-radius: 18px;
+        background: var(--bg-card);
+        border: 1px solid rgba(255, 255, 255, 0.05);
+        display: grid;
+        gap: 0.75rem;
+      }
+
+      .stat-card span {
+        font-size: 0.85rem;
+        color: var(--text-muted);
+      }
+
+      .stat-card strong {
+        font-size: 2.2rem;
+      }
+
+      .card-grid {
+        display: grid;
+        gap: 1.6rem;
+        grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+      }
+
+      .trail-card,
+      .guide-card {
+        background: var(--bg-card-light);
+        border: 1px solid rgba(255, 255, 255, 0.08);
+        border-radius: 18px;
+        padding: 1.6rem;
+        display: grid;
+        gap: 1rem;
+        backdrop-filter: blur(6px);
+      }
+
+      .trail-card h3,
+      .guide-card h3 {
+        margin: 0;
+        font-size: 1.25rem;
+      }
+
+      .tags {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.5rem;
+      }
+
+      .tag {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.4rem;
+        border-radius: 999px;
+        padding: 0.35rem 0.85rem;
+        background: rgba(91, 233, 185, 0.1);
+        color: var(--accent);
+        font-size: 0.8rem;
+        font-weight: 600;
+      }
+
+      .pill {
+        border-radius: 999px;
+        padding: 0.25rem 0.75rem;
+        background: rgba(255, 255, 255, 0.06);
+        color: var(--text-muted);
+        font-size: 0.75rem;
+      }
+
+      .benefits {
+        display: grid;
+        gap: 1.4rem;
+        grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+      }
+
+      .benefit {
+        background: rgba(255, 255, 255, 0.04);
+        border-radius: 18px;
+        padding: 1.5rem;
+        border: 1px solid rgba(255, 255, 255, 0.05);
+      }
+
+      .benefit h3 {
+        margin-top: 0;
+        font-size: 1.1rem;
+      }
+
+      .testimonial {
+        display: grid;
+        gap: 1.2rem;
+        background: linear-gradient(135deg, rgba(91, 233, 185, 0.15), rgba(11, 29, 38, 0.2));
+        border-radius: 18px;
+        padding: 1.8rem;
+      }
+
+      .testimonial blockquote {
+        margin: 0;
+        font-size: 1.1rem;
+        line-height: 1.6;
+        color: var(--text);
+      }
+
+      .testimonial cite {
+        font-style: normal;
+        color: var(--text-muted);
+      }
+
+      .map-placeholder {
+        border-radius: 18px;
+        background: rgba(255, 255, 255, 0.06);
+        border: 1px dashed rgba(255, 255, 255, 0.15);
+        padding: 2rem;
+        text-align: center;
+        display: grid;
+        place-items: center;
+        gap: 0.75rem;
+      }
+
+      .map-placeholder span {
+        font-size: 2.5rem;
+      }
+
+      footer {
+        padding: 2.5rem clamp(1.5rem, 5vw, 6.5rem) 3rem;
+        background: #08141d;
+        color: var(--text-muted);
+      }
+
+      footer nav {
+        margin: 0;
+        gap: 1rem;
+      }
+
+      footer p {
+        margin: 1.5rem 0 0;
+        font-size: 0.85rem;
+      }
+
+      @media (max-width: 720px) {
+        nav ul {
+          width: 100%;
+          justify-content: space-between;
+        }
+
+        header {
+          padding-bottom: 3.5rem;
+        }
+
+        .hero-actions {
+          flex-direction: column;
+          align-items: flex-start;
+        }
+
+        .search-grid {
+          grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <header>
+      <nav aria-label="Navegação principal">
+        <div class="logo">TreKKo</div>
+        <ul>
+          <li><a href="#explorar">Trilhas</a></li>
+          <li><a href="#guias">Guias</a></li>
+          <li><a href="#beneficios">Benefícios</a></li>
+          <li><a href="#seguranca">Segurança</a></li>
+        </ul>
+        <a class="cta" href="#login" aria-label="Entrar na plataforma TreKKo">
+          Entrar
+          <span aria-hidden="true">→</span>
+        </a>
+      </nav>
+      <div class="hero">
+        <span class="kicker">Aventura com segurança</span>
+        <h1>Conectamos trekkers apaixonados a guias oficiais CADASTUR</h1>
+        <p>
+          Planeje sua próxima expedição pelos biomas brasileiros com conteúdo confiável, guias
+          verificados e ferramentas inteligentes de busca. Na TreKKo você encontra trilhas
+          homologadas, mapas atualizados e uma comunidade ativa para compartilhar conquistas.
+        </p>
+        <div class="hero-actions">
+          <a class="cta" href="#explorar">Explorar trilhas</a>
+          <a class="secondary-cta" href="#guias">Conheça nossos guias certificados →</a>
+        </div>
+      </div>
+    </header>
+    <main>
+      <section class="search-card" aria-labelledby="busca">
+        <div>
+          <h2 id="busca">Encontre sua próxima trilha</h2>
+          <p>
+            Combine filtros por bioma, dificuldade, distância, camping, pet-friendly e disponibilidade
+            de guias credenciados.
+          </p>
+        </div>
+        <form class="search-grid" aria-label="Formulário de busca">
+          <label>
+            Palavra-chave
+            <input type="search" name="q" placeholder="Ex.: Pico da Bandeira" />
+          </label>
+          <label>
+            Localização
+            <input type="text" name="local" placeholder="Cidade, estado ou parque" />
+          </label>
+          <label>
+            Dificuldade
+            <select name="dificuldade">
+              <option>Qualquer</option>
+              <option>Iniciante</option>
+              <option>Intermediária</option>
+              <option>Avançada</option>
+            </select>
+          </label>
+          <label>
+            Duração
+            <select name="duracao">
+              <option>Qualquer</option>
+              <option>Até 1 dia</option>
+              <option>2 a 4 dias</option>
+              <option>5+ dias</option>
+            </select>
+          </label>
+          <label>
+            Guia obrigatório?
+            <select name="guia">
+              <option>Indiferente</option>
+              <option>Sim, obrigatório</option>
+              <option>Não, opcional</option>
+            </select>
+          </label>
+          <label>
+            Ordenar por
+            <select name="ordenacao">
+              <option>Relevância</option>
+              <option>Avaliação</option>
+              <option>Menor preço</option>
+              <option>Mais recentes</option>
+            </select>
+          </label>
+        </form>
+      </section>
+
+      <section aria-label="Indicadores da plataforma">
+        <div class="stats-grid">
+          <article class="stat-card" aria-label="Guias ativos">
+            <span>Guias CADASTUR ativos</span>
+            <strong>4.200+</strong>
+            <p class="pill">Validação dupla: BD oficial + moderação TreKKo</p>
+          </article>
+          <article class="stat-card" aria-label="Trilhas mapeadas">
+            <span>Trilhas mapeadas</span>
+            <strong>2.750</strong>
+            <p class="pill">Dados topográficos e pontos de água atualizados</p>
+          </article>
+          <article class="stat-card" aria-label="Avaliações verificadas">
+            <span>Avaliações verificadas</span>
+            <strong>38k</strong>
+            <p class="pill">Comunidade ativa em todos os biomas</p>
+          </article>
+          <article class="stat-card" aria-label="Expedições concluídas">
+            <span>Expedições concluídas</span>
+            <strong>96%</strong>
+            <p class="pill">Satisfação média com guias oficiais</p>
+          </article>
+        </div>
+      </section>
+
+      <section id="explorar" aria-labelledby="trilhas-populares">
+        <div>
+          <h2 id="trilhas-populares">Trilhas em destaque esta semana</h2>
+          <p>
+            Selecionamos rotas populares entre a comunidade, com dados de distância, ganho de elevação
+            e presença de guias homologados.
+          </p>
+        </div>
+        <div class="card-grid">
+          <article class="trail-card">
+            <div class="tags">
+              <span class="tag">Minas Gerais</span>
+              <span class="tag">Parque Nacional</span>
+            </div>
+            <h3>Pico da Bandeira</h3>
+            <p>Travessia clássica entre MG e ES com pernoite obrigatório no Terreirão.</p>
+            <div class="tags">
+              <span class="pill">23 km</span>
+              <span class="pill">↑ 1.200 m</span>
+              <span class="pill">Nível avançado</span>
+              <span class="pill">Guia recomendado</span>
+            </div>
+          </article>
+          <article class="trail-card">
+            <div class="tags">
+              <span class="tag">Amazonas</span>
+              <span class="tag">Selva</span>
+            </div>
+            <h3>Serra do Aracá</h3>
+            <p>Expedição de 6 dias com flutuação em rios de águas negras e visita ao maior platô do Brasil.</p>
+            <div class="tags">
+              <span class="pill">52 km</span>
+              <span class="pill">↑ 1.600 m</span>
+              <span class="pill">Nível avançado</span>
+              <span class="pill">Guia obrigatório</span>
+            </div>
+          </article>
+          <article class="trail-card">
+            <div class="tags">
+              <span class="tag">Santa Catarina</span>
+              <span class="tag">Costa</span>
+            </div>
+            <h3>Trilha da Lagoinha do Leste</h3>
+            <p>Trilha costeira com praias isoladas, pontos de água e mirantes panorâmicos.</p>
+            <div class="tags">
+              <span class="pill">8 km</span>
+              <span class="pill">↑ 430 m</span>
+              <span class="pill">Intermediária</span>
+              <span class="pill">Camping permitido</span>
+            </div>
+          </article>
+          <article class="trail-card">
+            <div class="tags">
+              <span class="tag">Piauí</span>
+              <span class="tag">Cânions</span>
+            </div>
+            <h3>Parque Nacional da Serra da Capivara</h3>
+            <p>Rotas circulares com arte rupestre e observação noturna guiada.</p>
+            <div class="tags">
+              <span class="pill">12 km</span>
+              <span class="pill">↑ 380 m</span>
+              <span class="pill">Iniciante</span>
+              <span class="pill">Guia obrigatório</span>
+            </div>
+          </article>
+        </div>
+      </section>
+
+      <section id="guias" aria-labelledby="guias-certificados">
+        <div>
+          <h2 id="guias-certificados">Guias oficiais recomendados</h2>
+          <p>
+            Dados sincronizados com o BD_CADASTUR garantem que cada profissional esteja regularizado. A
+            curadoria TreKKo avalia avaliações da comunidade, idiomas e especialidades.
+          </p>
+        </div>
+        <div class="card-grid">
+          <article class="guide-card">
+            <div class="tags">
+              <span class="tag">Acre • Brasiléia</span>
+              <span class="tag">Ecoturismo</span>
+            </div>
+            <h3>Charlisson Ribeiro de Oliveira</h3>
+            <p>Especialista em travessias amazônicas e roteiros culturais de fronteira Brasil-Peru.</p>
+            <div class="tags">
+              <span class="pill">Português / Espanhol</span>
+              <span class="pill">CADASTUR 04621967990</span>
+            </div>
+          </article>
+          <article class="guide-card">
+            <div class="tags">
+              <span class="tag">Acre • Cruzeiro do Sul</span>
+              <span class="tag">Turismo de Aventura</span>
+            </div>
+            <h3>Raeliton Lucas da Silva</h3>
+            <p>Guias expedições de floresta com foco em observação de fauna e cultura ribeirinha.</p>
+            <div class="tags">
+              <span class="pill">Português / Espanhol</span>
+              <span class="pill">CADASTUR 01855084620</span>
+            </div>
+          </article>
+          <article class="guide-card">
+            <div class="tags">
+              <span class="tag">Acre • Feijó</span>
+              <span class="tag">Cultura Indígena</span>
+            </div>
+            <h3>Francisca Andrea Shanenawa</h3>
+            <p>Guia indígena que conduz experiências imersivas em território Shanenawa com foco em saberes tradicionais.</p>
+            <div class="tags">
+              <span class="pill">Português</span>
+              <span class="pill">CADASTUR Ativo</span>
+            </div>
+          </article>
+          <article class="guide-card">
+            <div class="tags">
+              <span class="tag">Acre • Cruzeiro do Sul</span>
+              <span class="tag">Turismo Cultural</span>
+            </div>
+            <h3>Erik Rocha da Silva</h3>
+            <p>Lidera roteiros pelo Vale do Juruá integrando comunidades locais, gastronomia e trilhas de selva.</p>
+            <div class="tags">
+              <span class="pill">Português / Espanhol</span>
+              <span class="pill">CADASTUR 01458588584</span>
+            </div>
+          </article>
+        </div>
+      </section>
+
+      <section id="beneficios" aria-labelledby="beneficios-title">
+        <div>
+          <h2 id="beneficios-title">Benefícios para trekkers e guias</h2>
+          <p>
+            Uma plataforma completa para planejar, reservar e acompanhar expedições com segurança e
+            praticidade.
+          </p>
+        </div>
+        <div class="benefits">
+          <article class="benefit">
+            <h3>Planejamento inteligente</h3>
+            <p>
+              Compare trilhas por dificuldade, distância, ganho de elevação e disponibilidade de pontos
+              de água antes de reservar.
+            </p>
+          </article>
+          <article class="benefit">
+            <h3>Reserva com proteção</h3>
+            <p>
+              Pagamentos seguros, contratos digitais e suporte 24/7 para lidar com imprevistos durante a
+              expedição.
+            </p>
+          </article>
+          <article class="benefit">
+            <h3>Ativação de guias simplificada</h3>
+            <p>
+              Fluxo de ativação integrado ao CADASTUR com validação automática e painel para acompanhar
+              status e avaliações.
+            </p>
+          </article>
+          <article class="benefit">
+            <h3>Insights e comunidade</h3>
+            <p>
+              Receba alertas de condições climáticas, acompanhe métricas personalizadas e compartilhe
+              registros GPX com a comunidade TreKKo.
+            </p>
+          </article>
+        </div>
+      </section>
+
+      <section id="seguranca" aria-labelledby="seguranca-title">
+        <div>
+          <h2 id="seguranca-title">Segurança, observabilidade e desempenho</h2>
+          <p>
+            A TreKKo nasce com foco em confiabilidade: autenticação moderna, infraestrutura escalável e
+            monitoramento contínuo para proteger trekkers e guias.
+          </p>
+        </div>
+        <div class="card-grid">
+          <article class="trail-card">
+            <h3>Autenticação confiável</h3>
+            <p>Login por magic link, Google e Apple com sessões protegidas por cookies HTTP-only, CSRF e CAPTCHA Turnstile.</p>
+            <div class="tags">
+              <span class="pill">Timeout 24h</span>
+              <span class="pill">Rate limiting</span>
+            </div>
+          </article>
+          <article class="trail-card">
+            <h3>Performance e SEO</h3>
+            <p>Next.js com SSR/ISR, Core Web Vitals otimizados e metadados schema.org para posicionamento orgânico.</p>
+            <div class="tags">
+              <span class="pill">LCP &lt; 2,5s</span>
+              <span class="pill">CLS &lt; 0,1</span>
+              <span class="pill">INP &lt; 200ms</span>
+            </div>
+          </article>
+          <article class="trail-card">
+            <h3>Observabilidade ativa</h3>
+            <p>Eventos rastreiam buscas, filtros, aberturas de mapa e ativação de guias com alertas automáticos.</p>
+            <div class="tags">
+              <span class="pill">Falhas &lt; 3%</span>
+              <span class="pill">Logs de auditoria</span>
+            </div>
+          </article>
+          <article class="trail-card">
+            <h3>Experiência internacional</h3>
+            <p>Interface padrão em português com alternância para inglês, suporte a múltiplos idiomas de guias e moedas locais.</p>
+            <div class="tags">
+              <span class="pill">pt-BR / en-US</span>
+              <span class="pill">Conteúdo traduzido</span>
+            </div>
+          </article>
+        </div>
+      </section>
+
+      <section aria-label="Experiências de usuários">
+        <div class="testimonial">
+          <blockquote>
+            “Reservar minha travessia na Serra do Cipó com a TreKKo foi simples e transparente. Recebi
+            alertas climáticos, checklist personalizado e o guia homologado garantiu a segurança do meu
+            grupo.”
+          </blockquote>
+          <cite>— Juliana A., trekker desde 2016</cite>
+        </div>
+      </section>
+
+      <section aria-label="Cobertura nacional">
+        <div class="map-placeholder">
+          <span aria-hidden="true">🗺️</span>
+          <p>
+            Visualize no mapa a distribuição de trilhas e guias oficiais por estado. Em breve: filtros por
+            bioma, altitude e temperatura média.
+          </p>
+        </div>
+      </section>
+    </main>
+    <footer>
+      <nav aria-label="Rodapé">
+        <div class="logo">TreKKo</div>
+        <ul>
+          <li><a href="#" aria-label="Acesse o blog TreKKo">Blog</a></li>
+          <li><a href="#" aria-label="Conheça oportunidades de parceria">Parcerias</a></li>
+          <li><a href="#" aria-label="Suporte ao usuário">Suporte</a></li>
+          <li><a href="#" aria-label="Política de privacidade">Privacidade</a></li>
+        </ul>
+      </nav>
+      <p>TreKKo © 2024 — Plataforma brasileira para trekkers e guias oficiais CADASTUR.</p>
+    </footer>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add the TreKKo landing page HTML to the repository root for GitHub Pages
- duplicate the home page specification HTML at the root so it can be served directly

## Testing
- not run (static HTML content only)


------
https://chatgpt.com/codex/tasks/task_e_68e574928098832483616b070e8c3e02