### PR TITLE
Add Trekko multi-page frontend with dynamic integrations

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,0 +1,42 @@
+<!doctype html>
+<html lang="pt-BR">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>Página não encontrada — Trekko</title>
+  <meta name="description" content="A página solicitada não foi encontrada. Continue explorando trilhas e expedições." />
+  <link rel="preload" href="/assets/css/main.css" as="style" />
+  <link rel="stylesheet" href="/assets/css/main.css" />
+</head>
+<body>
+<a class="skip-link" href="#conteudo">Pular para o conteúdo</a>
+<header class="site-header">
+  <nav class="nav" aria-label="Principal">
+    <a class="nav__logo" href="/">Trekko</a>
+    <button class="nav__toggle" type="button" aria-expanded="false" aria-controls="menu">Menu</button>
+    <ul id="menu" class="nav__menu" data-state="closed">
+      <li><a href="/trilhas.html">Trilhas</a></li>
+      <li><a href="/guias.html">Guias CADASTUR</a></li>
+      <li><a href="/expedicoes.html">Expedições</a></li>
+    </ul>
+  </nav>
+</header>
+<main id="conteudo" class="section text-center">
+  <h1 class="section__title">Erro 404</h1>
+  <p class="section__description">A trilha que você tentou acessar não existe. Explore as opções abaixo.</p>
+  <div class="card__actions" style="justify-content:center;">
+    <a class="button button--primary" href="/trilhas.html">Ver trilhas</a>
+    <a class="button button--ghost" href="/">Ir para a Home</a>
+  </div>
+</main>
+<footer class="site-footer">
+  <nav aria-label="Rodapé">
+    <a href="/sobre.html">Sobre</a>
+    <a href="/contato.html">Contato</a>
+    <a href="/politica.html">Política e Termos</a>
+  </nav>
+  <small>© Trekko</small>
+</footer>
+<script src="/assets/js/main.js" defer></script>
+</body>
+</html>

--- a/500.html
+++ b/500.html
@@ -1,0 +1,42 @@
+<!doctype html>
+<html lang="pt-BR">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>Erro interno — Trekko</title>
+  <meta name="description" content="Ocorreu um erro interno. Nossa equipe já foi notificada." />
+  <link rel="preload" href="/assets/css/main.css" as="style" />
+  <link rel="stylesheet" href="/assets/css/main.css" />
+</head>
+<body>
+<a class="skip-link" href="#conteudo">Pular para o conteúdo</a>
+<header class="site-header">
+  <nav class="nav" aria-label="Principal">
+    <a class="nav__logo" href="/">Trekko</a>
+    <button class="nav__toggle" type="button" aria-expanded="false" aria-controls="menu">Menu</button>
+    <ul id="menu" class="nav__menu" data-state="closed">
+      <li><a href="/trilhas.html">Trilhas</a></li>
+      <li><a href="/guias.html">Guias CADASTUR</a></li>
+      <li><a href="/expedicoes.html">Expedições</a></li>
+    </ul>
+  </nav>
+</header>
+<main id="conteudo" class="section text-center">
+  <h1 class="section__title">Erro 500</h1>
+  <p class="section__description">Algo inesperado aconteceu. Nossa equipe técnica já foi alertada.</p>
+  <div class="card__actions" style="justify-content:center;">
+    <a class="button button--primary" href="/">Voltar para a Home</a>
+    <a class="button button--ghost" href="/contato.html">Falar com suporte</a>
+  </div>
+</main>
+<footer class="site-footer">
+  <nav aria-label="Rodapé">
+    <a href="/sobre.html">Sobre</a>
+    <a href="/contato.html">Contato</a>
+    <a href="/politica.html">Política e Termos</a>
+  </nav>
+  <small>© Trekko</small>
+</footer>
+<script src="/assets/js/main.js" defer></script>
+</body>
+</html>

--- a/admin.html
+++ b/admin.html
@@ -1,0 +1,90 @@
+<!doctype html>
+<html lang="pt-BR">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>Painel administrativo — Trekko</title>
+  <meta name="description" content="Área restrita para gestão da base CADASTUR, trilhas, expedições e usuários." />
+  <link rel="canonical" href="https://www.trekko.com.br/admin.html" />
+  <link rel="preload" href="/assets/css/main.css" as="style" />
+  <link rel="stylesheet" href="/assets/css/main.css" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; img-src 'self' https://images.unsplash.com https://cdn.trekko.com; connect-src 'self'; script-src 'self'; style-src 'self';" />
+</head>
+<body>
+<a class="skip-link" href="#painel">Pular para o conteúdo</a>
+<header class="site-header">
+  <nav class="nav" aria-label="Principal">
+    <a class="nav__logo" href="/">Trekko</a>
+    <button class="nav__toggle" type="button" aria-expanded="false" aria-controls="menu">Menu</button>
+    <ul id="menu" class="nav__menu" data-state="closed">
+      <li><a href="/trilhas.html">Trilhas</a></li>
+      <li><a href="/guias.html">Guias CADASTUR</a></li>
+      <li><a href="/expedicoes.html">Expedições</a></li>
+      <li><a href="/login.html" class="button button--ghost">Sair</a></li>
+    </ul>
+  </nav>
+</header>
+<main id="painel" class="section">
+  <header class="section__header">
+    <div>
+      <h1 class="section__title">Administração Trekko</h1>
+      <p class="section__description">Gerencie dados críticos, mantenha a base CADASTUR atualizada e valide expedições.</p>
+    </div>
+  </header>
+
+  <section class="section" aria-labelledby="cadastur-upload">
+    <h2 id="cadastur-upload" class="section__title">Base CADASTUR</h2>
+    <p>Atualize o CSV oficial (UTF-8) para que os guias possam ativar seus perfis. Somente arquivos com cabeçalhos padrão são aceitos.</p>
+    <form class="form" id="cadasturUploadForm" aria-label="Upload CADASTUR">
+      <div class="form__group">
+        <label for="cadasturFile">Arquivo CSV</label>
+        <input id="cadasturFile" name="cadasturFile" type="file" accept=".csv" required />
+      </div>
+      <button class="button button--primary" type="submit">Enviar arquivo</button>
+    </form>
+  </section>
+
+  <section class="section" aria-labelledby="gestao-trilhas">
+    <h2 id="gestao-trilhas" class="section__title">Gestão de trilhas</h2>
+    <p>Cadastre novas trilhas ou edite as existentes. As alterações refletem nos endpoints da API imediatamente.</p>
+    <div class="grid grid--two">
+      <article class="details-grid__item">
+        <h3>Importar trilhas</h3>
+        <p>Importe arquivos JSON ou GeoJSON conforme o padrão Trekko.</p>
+        <button class="button">Importar arquivo</button>
+      </article>
+      <article class="details-grid__item">
+        <h3>Publicar atualização</h3>
+        <p>Após revisar as trilhas, publique a atualização para os usuários.</p>
+        <button class="button button--primary">Publicar</button>
+      </article>
+    </div>
+  </section>
+
+  <section class="section" aria-labelledby="moderacao">
+    <h2 id="moderacao" class="section__title">Moderação</h2>
+    <div class="grid grid--two">
+      <article class="details-grid__item">
+        <h3>Expedições pendentes</h3>
+        <p>Analise expedições aguardando validação e aprove ou rejeite.</p>
+        <button class="button button--ghost">Ver pendências</button>
+      </article>
+      <article class="details-grid__item">
+        <h3>Usuários</h3>
+        <p>Gerencie permissões de administradores, guias e trilheiros.</p>
+        <button class="button button--ghost">Gerenciar usuários</button>
+      </article>
+    </div>
+  </section>
+</main>
+<footer class="site-footer">
+  <nav aria-label="Rodapé">
+    <a href="/sobre.html">Sobre</a>
+    <a href="/contato.html">Contato</a>
+    <a href="/politica.html">Política e Termos</a>
+  </nav>
+  <small>© Trekko</small>
+</footer>
+<script src="/assets/js/main.js" defer></script>
+</body>
+</html>

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1,0 +1,717 @@
+/*
+ * Trekko - CSS principal
+ * Paleta: verde #2D6A4F, marrom #7C4B2A, azul #1E3A5F, bege #E7D9C0, grafite #333333
+ */
+:root {
+  --color-green: #2d6a4f;
+  --color-brown: #7c4b2a;
+  --color-blue: #1e3a5f;
+  --color-sand: #e7d9c0;
+  --color-graphite: #333333;
+  --color-white: #ffffff;
+  --color-muted: #6f7378;
+  --font-heading: "Sora", "Outfit", "Segoe UI", sans-serif;
+  --font-body: "Outfit", "Sora", "Segoe UI", sans-serif;
+  --space-1: 0.25rem;
+  --space-2: 0.5rem;
+  --space-3: 0.75rem;
+  --space-4: 1rem;
+  --space-5: 1.5rem;
+  --space-6: 2rem;
+  --space-7: 2.5rem;
+  --space-8: 3rem;
+  --radius-sm: 0.5rem;
+  --radius-md: 0.75rem;
+  --radius-lg: 1rem;
+  --shadow-soft: 0 10px 30px rgba(0, 0, 0, 0.08);
+  --max-width: 1200px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  font-size: 16px;
+  scroll-behavior: smooth;
+}
+
+body {
+  margin: 0;
+  font-family: var(--font-body);
+  color: var(--color-graphite);
+  background-color: #f6f6f4;
+  line-height: 1.6;
+}
+
+a {
+  color: var(--color-blue);
+  text-decoration: none;
+}
+
+a:focus-visible,
+button:focus-visible,
+input:focus-visible,
+textarea:focus-visible,
+select:focus-visible {
+  outline: 3px solid var(--color-blue);
+  outline-offset: 3px;
+}
+
+img {
+  max-width: 100%;
+  height: auto;
+}
+
+main {
+  display: block;
+}
+
+.site-header {
+  background: var(--color-white);
+  border-bottom: 1px solid rgba(0, 0, 0, 0.05);
+  position: sticky;
+  top: 0;
+  z-index: 1000;
+}
+
+.nav {
+  max-width: var(--max-width);
+  margin: 0 auto;
+  padding: var(--space-3) var(--space-4);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.nav__logo {
+  font-family: var(--font-heading);
+  font-weight: 700;
+  font-size: 1.25rem;
+  color: var(--color-green);
+}
+
+.nav__toggle {
+  background: transparent;
+  border: 1px solid var(--color-green);
+  color: var(--color-green);
+  padding: var(--space-2) var(--space-3);
+  border-radius: var(--radius-sm);
+  font-size: 1rem;
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.nav__menu {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  gap: var(--space-3);
+}
+
+.nav__menu a {
+  padding: var(--space-2) var(--space-3);
+  border-radius: var(--radius-sm);
+}
+
+.nav__menu a:focus,
+.nav__menu a:hover {
+  background: rgba(45, 106, 79, 0.1);
+}
+
+.nav__menu[data-state="closed"] {
+  display: none;
+}
+
+@media (max-width: 768px) {
+  .nav__menu {
+    position: absolute;
+    top: 100%;
+    right: 0;
+    background: var(--color-white);
+    flex-direction: column;
+    width: min(260px, 90vw);
+    padding: var(--space-4);
+    box-shadow: var(--shadow-soft);
+  }
+}
+
+.site-footer {
+  background: var(--color-blue);
+  color: var(--color-white);
+  padding: var(--space-5) var(--space-4);
+  margin-top: var(--space-8);
+}
+
+.site-footer nav {
+  display: flex;
+  gap: var(--space-3);
+  flex-wrap: wrap;
+  margin-bottom: var(--space-3);
+}
+
+.site-footer a {
+  color: var(--color-white);
+}
+
+.section {
+  padding: var(--space-6) var(--space-4);
+}
+
+.section:nth-of-type(even) {
+  background: var(--color-white);
+}
+
+.section__header {
+  max-width: var(--max-width);
+  margin: 0 auto var(--space-4);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+}
+
+.section__title {
+  font-family: var(--font-heading);
+  font-size: clamp(1.5rem, 4vw, 2rem);
+  margin: 0;
+}
+
+.section__description {
+  color: var(--color-muted);
+  max-width: 520px;
+}
+
+.hero {
+  padding: var(--space-8) var(--space-4) var(--space-6);
+  background: linear-gradient(140deg, rgba(45, 106, 79, 0.9), rgba(30, 58, 95, 0.9)),
+    url("https://images.unsplash.com/photo-1500530855697-b586d89ba3ee?auto=format&fit=crop&w=1600&q=80") center/cover;
+  color: var(--color-white);
+}
+
+.hero__title {
+  font-family: var(--font-heading);
+  font-weight: 700;
+  font-size: clamp(2rem, 6vw, 3.2rem);
+  margin-bottom: var(--space-4);
+}
+
+.hero__subtitle {
+  font-size: 1.125rem;
+  max-width: 520px;
+  margin-bottom: var(--space-5);
+}
+
+.search-bar {
+  display: grid;
+  gap: var(--space-3);
+  max-width: 720px;
+}
+
+.search-bar__group {
+  display: grid;
+  gap: var(--space-2);
+}
+
+.search-bar__field,
+.search-bar input,
+.search-bar select,
+.filters input,
+.filters select,
+.filters textarea {
+  width: 100%;
+  padding: var(--space-3);
+  border-radius: var(--radius-sm);
+  border: 1px solid rgba(0, 0, 0, 0.2);
+  font-size: 1rem;
+  background: var(--color-white);
+}
+
+.autocomplete {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  background: var(--color-white);
+  border-radius: var(--radius-sm);
+  border: 1px solid rgba(0, 0, 0, 0.15);
+  box-shadow: var(--shadow-soft);
+  max-height: 320px;
+  overflow-y: auto;
+  position: relative;
+  z-index: 10;
+}
+
+.autocomplete li {
+  padding: var(--space-3);
+  cursor: pointer;
+}
+
+.autocomplete li[aria-selected="true"],
+.autocomplete li:hover {
+  background: rgba(45, 106, 79, 0.12);
+}
+
+.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-2);
+  padding: var(--space-3) var(--space-4);
+  border-radius: var(--radius-sm);
+  border: 1px solid transparent;
+  font-weight: 600;
+  font-size: 1rem;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.button--primary {
+  background: var(--color-green);
+  color: var(--color-white);
+  box-shadow: 0 10px 20px rgba(45, 106, 79, 0.2);
+}
+
+.button--ghost {
+  background: transparent;
+  border-color: var(--color-green);
+  color: var(--color-green);
+}
+
+.button--danger {
+  background: #b91c1c;
+  color: var(--color-white);
+}
+
+.button:hover {
+  transform: translateY(-1px);
+}
+
+.cards {
+  display: grid;
+  gap: var(--space-4);
+}
+
+.card {
+  background: var(--color-white);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-soft);
+  overflow: hidden;
+  display: grid;
+  grid-template-columns: 1fr;
+}
+
+.card__media {
+  width: 100%;
+  display: block;
+  object-fit: cover;
+}
+
+.card__body {
+  padding: var(--space-4);
+}
+
+.card__title {
+  margin: 0 0 var(--space-2);
+  font-family: var(--font-heading);
+  font-size: 1.25rem;
+}
+
+.card__meta {
+  margin: 0 0 var(--space-2);
+  color: var(--color-muted);
+}
+
+.card__location {
+  margin: 0 0 var(--space-4);
+  color: var(--color-graphite);
+}
+
+.card--guide {
+  grid-template-columns: auto 1fr;
+  align-items: center;
+  gap: var(--space-4);
+}
+
+.card__avatar {
+  border-radius: 50%;
+  width: 160px;
+  height: 160px;
+  object-fit: cover;
+  border: 4px solid var(--color-sand);
+}
+
+.card__actions {
+  display: flex;
+  gap: var(--space-3);
+  flex-wrap: wrap;
+}
+
+.estados-grid {
+  display: grid;
+  gap: var(--space-3);
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  max-width: var(--max-width);
+  margin: 0 auto;
+}
+
+.state-card {
+  background: var(--color-white);
+  border-radius: var(--radius-sm);
+  padding: var(--space-3);
+  display: grid;
+  gap: var(--space-2);
+  border: 1px solid rgba(0, 0, 0, 0.08);
+}
+
+.state-card__image {
+  width: 100%;
+  height: 120px;
+  border-radius: var(--radius-sm);
+  object-fit: cover;
+}
+
+.filters {
+  display: grid;
+  gap: var(--space-3);
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  padding: var(--space-4);
+  background: var(--color-white);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-soft);
+  margin-bottom: var(--space-4);
+}
+
+.filters fieldset {
+  border: 1px solid rgba(0, 0, 0, 0.1);
+  border-radius: var(--radius-sm);
+  padding: var(--space-3);
+}
+
+.filters legend {
+  padding: 0 var(--space-2);
+  font-weight: 600;
+}
+
+.pagination {
+  display: flex;
+  gap: var(--space-2);
+  align-items: center;
+  justify-content: center;
+  margin-top: var(--space-5);
+}
+
+.pagination__link {
+  padding: var(--space-2) var(--space-3);
+  border-radius: var(--radius-sm);
+  border: 1px solid rgba(0, 0, 0, 0.12);
+  background: var(--color-white);
+  color: inherit;
+}
+
+.pagination__link[aria-current="page"] {
+  background: var(--color-green);
+  color: var(--color-white);
+  border-color: var(--color-green);
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+  background: var(--color-white);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+}
+
+.table th,
+.table td {
+  padding: var(--space-3);
+  border-bottom: 1px solid rgba(0, 0, 0, 0.05);
+  text-align: left;
+}
+
+.table tbody tr:nth-child(even) {
+  background: rgba(231, 217, 192, 0.3);
+}
+
+.details-grid {
+  display: grid;
+  gap: var(--space-4);
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  margin-top: var(--space-4);
+}
+
+.details-grid__item {
+  background: var(--color-white);
+  border-radius: var(--radius-md);
+  padding: var(--space-4);
+  box-shadow: var(--shadow-soft);
+}
+
+.alert {
+  padding: var(--space-3);
+  border-radius: var(--radius-sm);
+  border: 1px solid transparent;
+}
+
+.alert--info {
+  background: rgba(30, 58, 95, 0.1);
+  border-color: rgba(30, 58, 95, 0.3);
+  color: var(--color-blue);
+}
+
+.alert--error {
+  background: rgba(185, 28, 28, 0.1);
+  border-color: rgba(185, 28, 28, 0.4);
+  color: #991b1b;
+}
+
+.form {
+  display: grid;
+  gap: var(--space-3);
+  max-width: 640px;
+  margin: 0 auto;
+}
+
+.form__group {
+  display: grid;
+  gap: var(--space-2);
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  background: rgba(45, 106, 79, 0.1);
+  color: var(--color-green);
+  padding: var(--space-1) var(--space-2);
+  border-radius: var(--radius-sm);
+  font-weight: 600;
+}
+
+.list {
+  padding-left: 1.25rem;
+}
+
+.grid {
+  display: grid;
+  gap: var(--space-4);
+}
+
+.grid--two {
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.iframe-wrapper {
+  position: relative;
+  padding-bottom: 56.25%;
+  height: 0;
+  overflow: hidden;
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-soft);
+}
+
+.iframe-wrapper iframe {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  border: 0;
+}
+
+[data-state="loading"]::after {
+  content: "Carregando...";
+  display: block;
+  padding: var(--space-4);
+  color: var(--color-muted);
+  font-style: italic;
+}
+
+[data-state="error"]::after {
+  content: "Não foi possível carregar os dados.";
+  display: block;
+  padding: var(--space-4);
+  color: #991b1b;
+}
+
+[data-state="empty"]::after {
+  content: "Nenhum resultado encontrado.";
+  display: block;
+  padding: var(--space-4);
+  color: var(--color-muted);
+}
+
+.skip-link {
+  position: absolute;
+  top: -100px;
+  left: 0;
+  background: var(--color-blue);
+  color: var(--color-white);
+  padding: var(--space-2) var(--space-3);
+  border-radius: 0 0 var(--radius-sm) 0;
+  z-index: 2000;
+}
+
+.skip-link:focus {
+  top: 0;
+}
+
+.table--pricing tbody tr td:first-child {
+  font-weight: 600;
+}
+
+.comment {
+  display: grid;
+  gap: var(--space-2);
+  padding: var(--space-3);
+  background: var(--color-white);
+  border-radius: var(--radius-sm);
+  border: 1px solid rgba(0, 0, 0, 0.05);
+}
+
+.comment__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  color: var(--color-muted);
+}
+
+.comment__author {
+  font-weight: 600;
+}
+
+.comment-form {
+  margin-top: var(--space-4);
+}
+
+.status-indicator {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  font-size: 0.875rem;
+  color: var(--color-muted);
+}
+
+.status-indicator::before {
+  content: "";
+  width: 0.75rem;
+  height: 0.75rem;
+  border-radius: 50%;
+  background: currentColor;
+}
+
+.status-indicator[data-state="loading"] {
+  color: var(--color-blue);
+}
+
+.status-indicator[data-state="error"] {
+  color: #b91c1c;
+}
+
+.alert-banner {
+  background: var(--color-brown);
+  color: var(--color-white);
+  padding: var(--space-2) var(--space-3);
+  text-align: center;
+  font-size: 0.875rem;
+}
+
+.form__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-3);
+  align-items: center;
+}
+
+.profile-header {
+  display: grid;
+  gap: var(--space-4);
+  grid-template-columns: 160px 1fr;
+  align-items: center;
+  margin-bottom: var(--space-5);
+}
+
+.profile-header__photo {
+  width: 160px;
+  height: 160px;
+  border-radius: 50%;
+  object-fit: cover;
+  border: 4px solid var(--color-sand);
+}
+
+.profile-header__info h1 {
+  margin: 0 0 var(--space-2);
+  font-family: var(--font-heading);
+}
+
+.event-card {
+  border-radius: var(--radius-md);
+  padding: var(--space-4);
+  background: var(--color-white);
+  box-shadow: var(--shadow-soft);
+  display: grid;
+  gap: var(--space-2);
+}
+
+.event-card__meta {
+  color: var(--color-muted);
+}
+
+.tag {
+  display: inline-flex;
+  background: rgba(30, 58, 95, 0.12);
+  color: var(--color-blue);
+  padding: var(--space-1) var(--space-2);
+  border-radius: var(--radius-sm);
+  font-size: 0.875rem;
+}
+
+.badge--status-success {
+  background: rgba(45, 106, 79, 0.15);
+  color: var(--color-green);
+}
+
+.text-center {
+  text-align: center;
+}
+
+.muted {
+  color: var(--color-muted);
+}
+
+@media (min-width: 768px) {
+  .cards {
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  }
+
+  .hero {
+    padding: var(--space-9) var(--space-4) var(--space-8);
+  }
+}
+
+@media (min-width: 1024px) {
+  .nav__toggle {
+    display: none;
+  }
+
+  .nav__menu {
+    position: static;
+    display: flex !important;
+    background: transparent;
+    box-shadow: none;
+  }
+
+  .card--guide {
+    grid-template-columns: 160px 1fr;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1,0 +1,1211 @@
+/* Trekko - JavaScript principal */
+(function () {
+  const selectors = {
+    navToggle: '.nav__toggle',
+    navMenu: '.nav__menu',
+    searchForm: '#searchForm',
+    autocomplete: '#autocomplete',
+    guideHighlights: '#guideHighlights',
+    trailHighlights: '#trailHighlights',
+    estadosGrid: '#estadosGrid',
+    trailsList: '#trailsList',
+    guidesList: '#guidesList',
+    expeditionsList: '#expeditionsList',
+  };
+
+  const state = {
+    autocompleteItems: [],
+    autocompleteActiveIndex: -1,
+  };
+
+  const debounce = (fn, delay = 250) => {
+    let timer;
+    return (...args) => {
+      clearTimeout(timer);
+      timer = setTimeout(() => fn(...args), delay);
+    };
+  };
+
+  const formatCurrency = (value) => {
+    if (value === null || value === undefined || value === '') return '—';
+    return Number(value).toLocaleString('pt-BR', {
+      style: 'currency',
+      currency: 'BRL',
+      minimumFractionDigits: 2,
+    });
+  };
+
+  const formatDate = (iso) => {
+    if (!iso) return '';
+    const date = new Date(iso);
+    if (Number.isNaN(date.getTime())) return '';
+    return date.toLocaleDateString('pt-BR');
+  };
+
+  const parseQuery = () => Object.fromEntries(new URLSearchParams(window.location.search));
+
+  const updateQuery = (params) => {
+    const url = new URL(window.location.href);
+    Object.entries(params).forEach(([key, value]) => {
+      if (value === undefined || value === null || value === '') {
+        url.searchParams.delete(key);
+      } else {
+        url.searchParams.set(key, value);
+      }
+    });
+    window.history.pushState({}, '', url);
+  };
+
+  const fetchJSON = async (url, options = {}) => {
+    const response = await fetch(url, {
+      headers: {
+        'Accept': 'application/json',
+        'Content-Type': 'application/json',
+      },
+      credentials: options.credentials || 'include',
+      ...options,
+    });
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(errorText || `Erro ${response.status}`);
+    }
+    return response.json();
+  };
+
+  const createTrailCard = (trail) => {
+    const article = document.createElement('article');
+    article.className = 'card card--trail';
+    article.setAttribute('itemscope', '');
+    article.setAttribute('itemtype', 'https://schema.org/TouristTrip');
+
+    const image = document.createElement('img');
+    image.className = 'card__media';
+    image.loading = 'lazy';
+    image.width = 400;
+    image.height = 250;
+    image.src = trail?.imageUrl || 'https://images.unsplash.com/photo-1469474968028-56623f02e42e?auto=format&fit=crop&w=800&q=80';
+    image.alt = trail?.imageAlt || `Vista da trilha ${trail?.nome || 'desconhecida'}`;
+    article.appendChild(image);
+
+    const body = document.createElement('div');
+    body.className = 'card__body';
+    article.appendChild(body);
+
+    const title = document.createElement('h3');
+    title.className = 'card__title';
+    title.itemProp = 'name';
+    title.textContent = trail?.nome || 'Trilha sem nome';
+    body.appendChild(title);
+
+    const meta = document.createElement('p');
+    meta.className = 'card__meta';
+    meta.innerHTML = `
+      <span itemprop="touristType">Nível: ${trail?.nivel || '—'}</span> •
+      <span><span itemprop="distance">${trail?.km || '—'}</span> km</span> •
+      <span>Ganho <span itemprop="itinerary">${trail?.ganho || '—'}</span> m</span>
+    `;
+    body.appendChild(meta);
+
+    const location = document.createElement('p');
+    location.className = 'card__location';
+    location.innerHTML = `${trail?.cidade || 'Cidade desconhecida'}, ${trail?.estado || 'UF'} • ${trail?.parque || 'Área de conservação'}`;
+    body.appendChild(location);
+
+    const link = document.createElement('a');
+    link.className = 'button button--ghost';
+    link.href = `/trilha.html?id=${encodeURIComponent(trail?.id)}`;
+    link.textContent = 'Ver detalhes';
+    body.appendChild(link);
+
+    return article;
+  };
+
+  const createGuideCard = (guide) => {
+    const article = document.createElement('article');
+    article.className = 'card card--guide';
+    article.setAttribute('itemscope', '');
+    article.setAttribute('itemtype', 'https://schema.org/Person');
+
+    const image = document.createElement('img');
+    image.className = 'card__avatar';
+    image.loading = 'lazy';
+    image.width = 160;
+    image.height = 160;
+    image.src = guide?.fotoUrl || 'https://images.unsplash.com/photo-1524504388940-b1c1722653e1?auto=format&fit=crop&w=320&q=80';
+    image.alt = guide?.fotoAlt || `Foto do guia ${guide?.nome || 'sem registro'}`;
+    article.appendChild(image);
+
+    const body = document.createElement('div');
+    body.className = 'card__body';
+    article.appendChild(body);
+
+    const title = document.createElement('h3');
+    title.className = 'card__title';
+    title.itemProp = 'name';
+    title.textContent = guide?.nome || 'Guia sem nome';
+    body.appendChild(title);
+
+    const cad = document.createElement('p');
+    cad.className = 'card__meta';
+    cad.innerHTML = `CADASTUR: <span itemprop="identifier">${guide?.cadastur || '—'}</span>`;
+    body.appendChild(cad);
+
+    const city = document.createElement('p');
+    city.className = 'card__meta';
+    city.textContent = `UF/Cidade: ${guide?.uf || '—'} — ${guide?.municipio || '—'}`;
+    body.appendChild(city);
+
+    const actions = document.createElement('div');
+    actions.className = 'card__actions';
+    body.appendChild(actions);
+
+    const profile = document.createElement('a');
+    profile.className = 'button button--primary';
+    profile.href = `/guia.html?id=${encodeURIComponent(guide?.id)}`;
+    profile.textContent = 'Ver perfil';
+    actions.appendChild(profile);
+
+    if (guide?.contatos?.whatsapp) {
+      const wa = document.createElement('a');
+      wa.className = 'button';
+      wa.href = `https://wa.me/${guide.contatos.whatsapp.replace(/\D/g, '')}`;
+      wa.target = '_blank';
+      wa.rel = 'noopener';
+      wa.textContent = 'WhatsApp';
+      actions.appendChild(wa);
+    }
+
+    return article;
+  };
+
+  const renderStateCard = (stateData) => {
+    const article = document.createElement('article');
+    article.className = 'state-card';
+    article.innerHTML = `
+      <img class="state-card__image" src="${stateData.imageUrl || 'https://images.unsplash.com/photo-1523419409543-0c1df022bdd1?auto=format&fit=crop&w=400&q=80'}" alt="Paisagem do estado ${stateData.uf}" loading="lazy" width="320" height="180" />
+      <div>
+        <p class="badge">${stateData.total} trilhas</p>
+        <h3>${stateData.uf}</h3>
+        <p class="muted">${stateData.cidade || ''}</p>
+      </div>
+      <a class="button button--ghost" href="/trilhas.html?estado=${stateData.uf}">Explorar</a>
+    `;
+    return article;
+  };
+
+  const updateDataState = (element, stateName) => {
+    if (!element) return;
+    element.dataset.state = stateName;
+    element.setAttribute('aria-busy', stateName === 'loading' ? 'true' : 'false');
+  };
+
+  const initNav = () => {
+    const toggle = document.querySelector(selectors.navToggle);
+    const menu = document.querySelector(selectors.navMenu);
+    if (!toggle || !menu) return;
+    const closeMenu = () => {
+      menu.dataset.state = 'closed';
+      toggle.setAttribute('aria-expanded', 'false');
+    };
+    closeMenu();
+    toggle.addEventListener('click', () => {
+      const expanded = toggle.getAttribute('aria-expanded') === 'true';
+      toggle.setAttribute('aria-expanded', String(!expanded));
+      if (expanded) {
+        closeMenu();
+      } else {
+        menu.dataset.state = 'open';
+      }
+    });
+    document.addEventListener('keyup', (event) => {
+      if (event.key === 'Escape') {
+        closeMenu();
+        toggle.focus();
+      }
+    });
+  };
+
+  const initSearchAutocomplete = () => {
+    const form = document.querySelector(selectors.searchForm);
+    const list = document.querySelector(selectors.autocomplete);
+    if (!form || !list) return;
+    const input = form.querySelector('input[type="search"]');
+    if (!input) return;
+
+    const closeList = () => {
+      list.hidden = true;
+      list.innerHTML = '';
+      state.autocompleteItems = [];
+      state.autocompleteActiveIndex = -1;
+    };
+
+    const openList = () => {
+      list.hidden = false;
+    };
+
+    const renderItems = (items) => {
+      list.innerHTML = '';
+      if (!items.length) {
+        closeList();
+        return;
+      }
+      items.forEach((item, index) => {
+        const li = document.createElement('li');
+        li.id = `autocomplete-${index}`;
+        li.role = 'option';
+        li.textContent = item.label;
+        li.dataset.value = item.value;
+        li.addEventListener('mousedown', (event) => {
+          event.preventDefault();
+          input.value = item.value;
+          closeList();
+          form.submit();
+        });
+        list.appendChild(li);
+      });
+      openList();
+    };
+
+    const search = debounce(async (value) => {
+      if (!value || value.length < 2) {
+        closeList();
+        return;
+      }
+      try {
+        const data = await fetchJSON(`/api/search/autocomplete?q=${encodeURIComponent(value)}`);
+        const items = (data?.results || []).map((result) => ({
+          label: `${result.nome} — ${result.cidade || result.parque || result.estado || ''}`.trim(),
+          value: result.nome || result.cidade || result.estado,
+        }));
+        state.autocompleteItems = items;
+        renderItems(items);
+      } catch (error) {
+        console.warn('Autocomplete error', error);
+        closeList();
+      }
+    }, 250);
+
+    input.addEventListener('input', (event) => {
+      search(event.target.value);
+    });
+
+    input.addEventListener('keydown', (event) => {
+      const items = Array.from(list.querySelectorAll('li'));
+      if (!items.length) return;
+      switch (event.key) {
+        case 'ArrowDown':
+          event.preventDefault();
+          state.autocompleteActiveIndex = (state.autocompleteActiveIndex + 1) % items.length;
+          break;
+        case 'ArrowUp':
+          event.preventDefault();
+          state.autocompleteActiveIndex = (state.autocompleteActiveIndex - 1 + items.length) % items.length;
+          break;
+        case 'Enter':
+          if (state.autocompleteActiveIndex >= 0) {
+            event.preventDefault();
+            const item = state.autocompleteItems[state.autocompleteActiveIndex];
+            input.value = item?.value || input.value;
+            closeList();
+            form.submit();
+          }
+          break;
+        case 'Escape':
+          closeList();
+          break;
+        default:
+          break;
+      }
+      items.forEach((item, index) => {
+        const isSelected = index === state.autocompleteActiveIndex;
+        item.setAttribute('aria-selected', String(isSelected));
+        if (isSelected) {
+          input.setAttribute('aria-activedescendant', item.id);
+        }
+      });
+    });
+
+    document.addEventListener('click', (event) => {
+      if (!list.contains(event.target) && event.target !== input) {
+        closeList();
+      }
+    });
+  };
+
+  const initHighlights = async () => {
+    const trailContainer = document.querySelector(selectors.trailHighlights);
+    if (trailContainer) {
+      updateDataState(trailContainer, 'loading');
+      try {
+        const data = await fetchJSON('/api/trails?limit=10&sort=featured');
+        const trails = data?.data || data?.results || [];
+        if (!trails.length) {
+          updateDataState(trailContainer, 'empty');
+        } else {
+          trailContainer.innerHTML = '';
+          trails.forEach((trail) => trailContainer.appendChild(createTrailCard(trail)));
+          updateDataState(trailContainer, 'ready');
+        }
+      } catch (error) {
+        console.error(error);
+        updateDataState(trailContainer, 'error');
+      }
+    }
+
+    const guideContainer = document.querySelector(selectors.guideHighlights);
+    if (guideContainer) {
+      updateDataState(guideContainer, 'loading');
+      try {
+        const data = await fetchJSON('/api/guides?limit=4&sort=featured');
+        const guides = data?.data || data?.results || [];
+        if (!guides.length) {
+          updateDataState(guideContainer, 'empty');
+        } else {
+          guideContainer.innerHTML = '';
+          guides.forEach((guide) => guideContainer.appendChild(createGuideCard(guide)));
+          updateDataState(guideContainer, 'ready');
+        }
+      } catch (error) {
+        console.error(error);
+        updateDataState(guideContainer, 'error');
+      }
+    }
+
+    const estadosGrid = document.querySelector(selectors.estadosGrid);
+    if (estadosGrid) {
+      updateDataState(estadosGrid, 'loading');
+      try {
+        const data = await fetchJSON('/api/trails/states');
+        const states = data?.data || data?.results || [];
+        if (!states.length) {
+          updateDataState(estadosGrid, 'empty');
+        } else {
+          estadosGrid.innerHTML = '';
+          states.forEach((stateInfo) => estadosGrid.appendChild(renderStateCard(stateInfo)));
+          updateDataState(estadosGrid, 'ready');
+        }
+      } catch (error) {
+        console.error(error);
+        updateDataState(estadosGrid, 'error');
+      }
+    }
+  };
+
+  const renderPagination = ({ container, meta, onPageChange }) => {
+    if (!container || !meta) return;
+    const { page = 1, totalPages = 1 } = meta;
+    container.innerHTML = '';
+    if (totalPages <= 1) {
+      container.hidden = true;
+      return;
+    }
+    container.hidden = false;
+    const createLink = (label, targetPage, disabled = false, ariaLabel) => {
+      const button = document.createElement('button');
+      button.type = 'button';
+      button.className = 'pagination__link';
+      button.textContent = label;
+      if (ariaLabel) button.setAttribute('aria-label', ariaLabel);
+      if (disabled) {
+        button.disabled = true;
+        button.setAttribute('aria-disabled', 'true');
+      } else {
+        button.addEventListener('click', () => onPageChange(targetPage));
+      }
+      return button;
+    };
+
+    container.appendChild(createLink('Anterior', page - 1, page <= 1, 'Página anterior'));
+    for (let p = 1; p <= totalPages; p += 1) {
+      const link = createLink(String(p), p, false, `Ir para página ${p}`);
+      if (p === page) {
+        link.setAttribute('aria-current', 'page');
+      }
+      container.appendChild(link);
+    }
+    container.appendChild(createLink('Próxima', page + 1, page >= totalPages, 'Próxima página'));
+  };
+
+  const initTrailsList = () => {
+    const listContainer = document.querySelector(selectors.trailsList);
+    if (!listContainer) return;
+    const form = document.querySelector('#trailFilters');
+    const counter = document.querySelector('#trailCounter');
+    const pagination = document.querySelector('#trailPagination');
+
+    const applyFiltersFromQuery = () => {
+      if (!form) return;
+      const params = parseQuery();
+      Array.from(form.elements).forEach((field) => {
+        if (!(field instanceof HTMLInputElement || field instanceof HTMLSelectElement)) return;
+        if (field.type === 'checkbox') {
+          field.checked = params[field.name] === 'true';
+        } else {
+          field.value = params[field.name] || '';
+        }
+      });
+    };
+
+    const buildQuery = () => {
+      const params = new URLSearchParams();
+      if (!form) return params;
+      Array.from(form.elements).forEach((field) => {
+        if (!(field instanceof HTMLInputElement || field instanceof HTMLSelectElement)) return;
+        if (!field.name) return;
+        if (field.type === 'checkbox') {
+          if (field.checked) params.set(field.name, 'true');
+        } else if (field.value) {
+          params.set(field.name, field.value);
+        }
+      });
+      return params;
+    };
+
+    const loadTrails = async () => {
+      updateDataState(listContainer, 'loading');
+      const params = buildQuery();
+      const url = `/api/trails?${params.toString()}`;
+      try {
+        const data = await fetchJSON(url);
+        const trails = data?.data || data?.results || [];
+        const meta = data?.meta || { total: trails.length, page: Number(params.get('page')) || 1, perPage: trails.length, totalPages: data?.totalPages || 1 };
+        listContainer.innerHTML = '';
+        if (!trails.length) {
+          updateDataState(listContainer, 'empty');
+        } else {
+          trails.forEach((trail) => listContainer.appendChild(createTrailCard(trail)));
+          updateDataState(listContainer, 'ready');
+        }
+        if (counter) {
+          const from = (meta.page - 1) * meta.perPage + (trails.length ? 1 : 0);
+          const to = (meta.page - 1) * meta.perPage + trails.length;
+          counter.textContent = trails.length ? `Exibindo ${from}–${to} de ${meta.total} trilhas` : 'Nenhuma trilha encontrada';
+        }
+        if (pagination) {
+          renderPagination({
+            container: pagination,
+            meta: {
+              page: meta.page,
+              totalPages: meta.totalPages || Math.ceil((meta.total || trails.length) / (meta.perPage || 1)) || 1,
+            },
+            onPageChange: (page) => {
+              updateQuery({ page });
+              if (form) {
+                const pageField = form.querySelector('[name="page"]');
+                if (pageField) {
+                  pageField.value = page;
+                } else {
+                  const hidden = document.createElement('input');
+                  hidden.type = 'hidden';
+                  hidden.name = 'page';
+                  hidden.value = page;
+                  form.appendChild(hidden);
+                }
+              }
+              window.scrollTo({ top: 0, behavior: 'smooth' });
+              loadTrails();
+            },
+          });
+        }
+      } catch (error) {
+        console.error(error);
+        updateDataState(listContainer, 'error');
+        if (counter) counter.textContent = 'Erro ao carregar trilhas.';
+      }
+    };
+
+    applyFiltersFromQuery();
+
+    if (form) {
+      form.addEventListener('submit', (event) => {
+        event.preventDefault();
+        const params = buildQuery();
+        updateQuery(Object.fromEntries(params.entries()));
+        loadTrails();
+      });
+    }
+
+    window.addEventListener('popstate', () => {
+      applyFiltersFromQuery();
+      loadTrails();
+    });
+
+    loadTrails();
+  };
+
+  const initTrailDetails = async () => {
+    const trailMain = document.querySelector('[data-trail-details]');
+    if (!trailMain) return;
+    const params = parseQuery();
+    const { id } = params;
+    if (!id) return;
+
+    const status = trailMain.querySelector('[data-trail-status]');
+    if (status) status.dataset.state = 'loading';
+
+    try {
+      const trail = await fetchJSON(`/api/trails/${encodeURIComponent(id)}`);
+      renderTrailDetail(trail);
+      if (status) status.dataset.state = 'ready';
+      if (trail?.nome) {
+        document.title = `${trail.nome} — Trekko`;
+        const canonical = document.querySelector('link[rel="canonical"]');
+        if (canonical) {
+          const url = new URL(window.location.href);
+          canonical.href = url.href;
+        }
+      }
+      loadTrailExpeditions(id);
+      loadTrailComments(id);
+    } catch (error) {
+      console.error(error);
+      if (status) status.dataset.state = 'error';
+    }
+  };
+
+  const updateTrailSchema = (trail) => {
+    const script = document.querySelector('#trailSchema');
+    if (!script) return;
+    const schema = {
+      '@context': 'https://schema.org',
+      '@type': 'TouristTrip',
+      name: trail?.nome,
+      description: trail?.descricao,
+      itinerary: `${trail?.cidade || ''}, ${trail?.estado || ''}`.trim(),
+      touristType: trail?.nivel,
+      distance: trail?.km ? `${trail.km} km` : undefined,
+      provider: trail?.parque,
+      offers: {
+        '@type': 'Offer',
+        price: trail?.entradaPaga ? trail?.valorEntrada : 0,
+        priceCurrency: 'BRL',
+        availability: 'https://schema.org/InStock',
+      },
+    };
+    script.textContent = JSON.stringify(schema);
+  };
+
+  const renderTrailDetail = (trail) => {
+    const nameEl = document.querySelector('[data-trail-name]');
+    if (nameEl) nameEl.textContent = trail?.nome || 'Trilha';
+
+    const summaryEl = document.querySelector('[data-trail-summary]');
+    if (summaryEl) summaryEl.textContent = trail?.descricao || '';
+
+    const metaEl = document.querySelector('[data-trail-meta]');
+    if (metaEl) metaEl.textContent = `${trail?.nivel || '—'} • ${trail?.km || '—'} km • Ganho ${trail?.ganho || '—'} m`;
+
+    const locationEl = document.querySelector('[data-trail-location]');
+    if (locationEl) locationEl.textContent = `${trail?.cidade || ''} — ${trail?.estado || ''} • ${trail?.parque || ''}`;
+
+    const costTable = document.querySelector('[data-trail-costs] tbody');
+    if (costTable) {
+      costTable.innerHTML = `
+        <tr><td>Entrada</td><td>${trail?.entradaPaga ? formatCurrency(trail?.valorEntrada) : 'Gratuita'}</td></tr>
+        <tr><td>Camping</td><td>${trail?.camping ? formatCurrency(trail?.valorCamping) : 'Não possui'}</td></tr>
+        <tr><td>Estacionamento</td><td>${trail?.estacionamento ? formatCurrency(trail?.valorEstacionamento) : 'Não possui'}</td></tr>
+      `;
+    }
+
+    const infraList = document.querySelector('[data-trail-infra]');
+    if (infraList) {
+      infraList.innerHTML = '';
+      const facilities = [
+        trail?.agua ? 'Pontos de água disponíveis' : 'Sem pontos de água',
+        trail?.camping ? 'Área de camping disponível' : 'Sem área de camping',
+        trail?.estacionamento ? 'Estacionamento disponível' : 'Sem estacionamento no local',
+      ];
+      facilities.forEach((facility) => {
+        const li = document.createElement('li');
+        li.textContent = facility;
+        infraList.appendChild(li);
+      });
+    }
+
+    const logistics = document.querySelector('[data-trail-logistics]');
+    if (logistics) {
+      logistics.innerHTML = '';
+      const transport = trail?.logistica || [];
+      transport.forEach((item) => {
+        const div = document.createElement('div');
+        div.className = 'details-grid__item';
+        div.innerHTML = `
+          <h3>${item.tipo}</h3>
+          <p class="muted">${item.nome} — ${item.cidade}</p>
+          <p class="badge">${item.distanciaKm} km</p>
+        `;
+        logistics.appendChild(div);
+      });
+    }
+
+    const mapFrame = document.querySelector('[data-trail-map]');
+    if (mapFrame) {
+      mapFrame.src = trail?.mapaUrl || 'https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3673.829105538956!2d-43.1779092!3d-22.9068466!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x997f5bdf3bd3ab%3A0x8d546c1f9e4edc35!2sBrasil!5e0!3m2!1spt-BR!2sbr!4v1600000000000!5m2!1spt-BR!2sbr';
+    }
+
+    updateTrailSchema(trail);
+  };
+
+  const loadTrailExpeditions = async (trailId) => {
+    const container = document.querySelector('#trailExpeditions');
+    if (!container) return;
+    updateDataState(container, 'loading');
+    try {
+      const data = await fetchJSON(`/api/expeditions?trailId=${encodeURIComponent(trailId)}&from=${encodeURIComponent(new Date().toISOString())}`);
+      const expeditions = data?.data || data?.results || [];
+      container.innerHTML = '';
+      if (!expeditions.length) {
+        updateDataState(container, 'empty');
+      } else {
+        expeditions.forEach((expedition) => container.appendChild(renderExpeditionCard(expedition)));
+        updateDataState(container, 'ready');
+      }
+    } catch (error) {
+      console.error(error);
+      updateDataState(container, 'error');
+    }
+  };
+
+  const renderExpeditionCard = (expedition) => {
+    const article = document.createElement('article');
+    article.className = 'event-card';
+    article.setAttribute('itemscope', '');
+    article.setAttribute('itemtype', 'https://schema.org/Event');
+    article.innerHTML = `
+      <h3 itemprop="name">${expedition?.titulo || expedition?.trail?.nome || 'Expedição'}</h3>
+      <p class="event-card__meta">
+        <span class="tag" itemprop="startDate">${formatDate(expedition?.inicio)}</span>
+        <span class="tag" itemprop="endDate">${formatDate(expedition?.fim)}</span>
+        <span class="tag">${expedition?.vagas || 0} vagas</span>
+      </p>
+      <p>${expedition?.descricao || ''}</p>
+      <p class="badge">${formatCurrency(expedition?.precoPorPessoa)} por pessoa</p>
+      <a class="button button--primary" href="/expedicoes.html?trailId=${encodeURIComponent(expedition?.trailId)}">Agendar</a>
+    `;
+    return article;
+  };
+
+  const loadTrailComments = async (trailId) => {
+    const container = document.querySelector('#trailComments');
+    if (!container) return;
+    const list = container.querySelector('[data-comments-list]');
+    const status = container.querySelector('.status-indicator');
+    if (status) status.dataset.state = 'loading';
+    try {
+      const data = await fetchJSON(`/api/trails/${encodeURIComponent(trailId)}/comments`);
+      const comments = data?.data || data?.results || [];
+      list.innerHTML = '';
+      if (!comments.length) {
+        list.innerHTML = '<p class="muted">Nenhum comentário ainda. Seja o primeiro a compartilhar sua experiência.</p>';
+        if (status) status.dataset.state = 'ready';
+        return;
+      }
+      comments.forEach((comment) => {
+        const article = document.createElement('article');
+        article.className = 'comment';
+        article.innerHTML = `
+          <header class="comment__header">
+            <span class="comment__author">${comment?.autor || 'Anônimo'}</span>
+            <time class="muted" datetime="${comment?.criadoEm}">${formatDate(comment?.criadoEm)}</time>
+          </header>
+          <p>${comment?.mensagem || ''}</p>
+        `;
+        list.appendChild(article);
+      });
+      if (status) status.dataset.state = 'ready';
+    } catch (error) {
+      console.error(error);
+      if (status) status.dataset.state = 'error';
+    }
+  };
+
+  const initCommentForm = () => {
+    const form = document.querySelector('#commentForm');
+    if (!form) return;
+    form.addEventListener('submit', async (event) => {
+      event.preventDefault();
+      const submitButton = form.querySelector('button[type="submit"]');
+      if (submitButton) submitButton.disabled = true;
+      const formData = new FormData(form);
+      const trailId = form.dataset.trailId;
+      try {
+        const payload = Object.fromEntries(formData.entries());
+        await fetchJSON(`/api/trails/${encodeURIComponent(trailId)}/comments`, {
+          method: 'POST',
+          body: JSON.stringify(payload),
+        });
+        form.reset();
+        loadTrailComments(trailId);
+      } catch (error) {
+        alert('Não foi possível enviar seu comentário. Faça login e tente novamente.');
+      } finally {
+        if (submitButton) submitButton.disabled = false;
+      }
+    });
+  };
+
+  const initGuidesList = () => {
+    const list = document.querySelector(selectors.guidesList);
+    if (!list) return;
+    const form = document.querySelector('#guideFilters');
+    const pagination = document.querySelector('#guidePagination');
+    const updatedAt = document.querySelector('#cadasturUpdatedAt');
+
+    const applyFilters = () => {
+      if (!form) return;
+      const params = parseQuery();
+      Array.from(form.elements).forEach((field) => {
+        if (!(field instanceof HTMLInputElement || field instanceof HTMLSelectElement)) return;
+        if (field.type === 'checkbox') {
+          field.checked = params[field.name] === 'true';
+        } else {
+          field.value = params[field.name] || '';
+        }
+      });
+    };
+
+    const buildQuery = () => {
+      const params = new URLSearchParams();
+      if (!form) return params;
+      Array.from(form.elements).forEach((field) => {
+        if (!(field instanceof HTMLInputElement || field instanceof HTMLSelectElement)) return;
+        if (!field.name) return;
+        if (field.value) params.set(field.name, field.value);
+      });
+      return params;
+    };
+
+    const loadGuides = async () => {
+      updateDataState(list, 'loading');
+      const params = buildQuery();
+      if (!params.get('page')) params.set('page', '1');
+      if (!params.get('limit')) params.set('limit', '30');
+      try {
+        const data = await fetchJSON(`/api/guides?${params.toString()}`);
+        const guides = data?.data || data?.results || [];
+        const meta = data?.meta || { page: Number(params.get('page')), totalPages: 1 };
+        list.innerHTML = '';
+        if (!guides.length) {
+          updateDataState(list, 'empty');
+        } else {
+          guides.forEach((guide) => list.appendChild(createGuideCard(guide)));
+          updateDataState(list, 'ready');
+        }
+        if (updatedAt && data?.meta?.updatedAt) {
+          updatedAt.textContent = formatDate(data.meta.updatedAt);
+        }
+        if (pagination) {
+          renderPagination({
+            container: pagination,
+            meta: {
+              page: meta.page,
+              totalPages: meta.totalPages || Math.ceil((meta.total || guides.length) / 30) || 1,
+            },
+            onPageChange: (page) => {
+              updateQuery({ page });
+              params.set('page', String(page));
+              window.scrollTo({ top: 0, behavior: 'smooth' });
+              loadGuides();
+            },
+          });
+        }
+      } catch (error) {
+        console.error(error);
+        updateDataState(list, 'error');
+      }
+    };
+
+    applyFilters();
+
+    if (form) {
+      form.addEventListener('submit', (event) => {
+        event.preventDefault();
+        const params = buildQuery();
+        updateQuery(Object.fromEntries(params.entries()));
+        loadGuides();
+      });
+    }
+
+    window.addEventListener('popstate', () => {
+      applyFilters();
+      loadGuides();
+    });
+
+    loadGuides();
+  };
+
+  const initGuideProfile = async () => {
+    const container = document.querySelector('[data-guide-profile]');
+    if (!container) return;
+    const params = parseQuery();
+    const { id } = params;
+    if (!id) return;
+    const status = container.querySelector('.status-indicator');
+    if (status) status.dataset.state = 'loading';
+    try {
+      const guide = await fetchJSON(`/api/guides/${encodeURIComponent(id)}`);
+      renderGuideProfile(guide);
+      if (status) status.dataset.state = 'ready';
+      loadGuideExpeditions(id);
+    } catch (error) {
+      console.error(error);
+      if (status) status.dataset.state = 'error';
+    }
+  };
+
+  const updateGuideSchema = (guide) => {
+    const script = document.querySelector('#guideSchema');
+    if (!script) return;
+    const schema = {
+      '@context': 'https://schema.org',
+      '@type': 'Person',
+      name: guide?.nome,
+      identifier: guide?.cadastur,
+      address: {
+        '@type': 'PostalAddress',
+        addressRegion: guide?.uf,
+        addressLocality: guide?.municipio,
+        addressCountry: 'BR',
+      },
+      description: guide?.bio,
+      image: guide?.fotoUrl,
+      sameAs: Object.values(guide?.contatos || {}).filter(Boolean),
+    };
+    script.textContent = JSON.stringify(schema);
+  };
+
+  const renderGuideProfile = (guide) => {
+    const nameEl = document.querySelector('[data-guide-name]');
+    if (nameEl) nameEl.textContent = guide?.nome || 'Guia';
+    const cadEl = document.querySelector('[data-guide-cadastur]');
+    if (cadEl) cadEl.textContent = guide?.cadastur || '—';
+    const cityEl = document.querySelector('[data-guide-city]');
+    if (cityEl) cityEl.textContent = `${guide?.municipio || ''} — ${guide?.uf || ''}`;
+    const bioEl = document.querySelector('[data-guide-bio]');
+    if (bioEl) bioEl.textContent = guide?.bio || 'Este guia ainda não escreveu uma biografia.';
+    const photoEl = document.querySelector('[data-guide-photo]');
+    if (photoEl) {
+      photoEl.src = guide?.fotoUrl || photoEl.src;
+      photoEl.alt = `Foto do guia ${guide?.nome}`;
+    }
+    const contactsList = document.querySelector('[data-guide-contacts]');
+    if (contactsList) {
+      contactsList.innerHTML = '';
+      const contacts = guide?.contatos || {};
+      Object.entries(contacts).forEach(([key, value]) => {
+        if (!value) return;
+        const li = document.createElement('li');
+        const label = key.replace(/_/g, ' ');
+        if (key === 'whatsapp') {
+          const sanitized = value.replace(/\D/g, '');
+          li.innerHTML = `<a href="https://wa.me/${sanitized}" target="_blank" rel="noopener">WhatsApp: ${value}</a>`;
+        } else {
+          li.textContent = `${label}: ${value}`;
+        }
+        contactsList.appendChild(li);
+      });
+    }
+    const whatsappButton = document.querySelector('[data-guide-whatsapp]');
+    if (whatsappButton && guide?.contatos?.whatsapp) {
+      whatsappButton.href = `https://wa.me/${guide.contatos.whatsapp.replace(/\D/g, '')}`;
+    }
+
+    updateGuideSchema(guide);
+  };
+
+  const loadGuideExpeditions = async (guideId) => {
+    const container = document.querySelector('#guideExpeditions');
+    if (!container) return;
+    updateDataState(container, 'loading');
+    try {
+      const data = await fetchJSON(`/api/expeditions?guideId=${encodeURIComponent(guideId)}`);
+      const expeditions = data?.data || data?.results || [];
+      container.innerHTML = '';
+      if (!expeditions.length) {
+        updateDataState(container, 'empty');
+      } else {
+        expeditions.forEach((expedition) => container.appendChild(renderExpeditionCard(expedition)));
+        updateDataState(container, 'ready');
+      }
+    } catch (error) {
+      console.error(error);
+      updateDataState(container, 'error');
+    }
+  };
+
+  const initExpeditionForm = () => {
+    const form = document.querySelector('#expeditionForm');
+    if (!form) return;
+    const trailSelect = form.querySelector('[name="trailId"]');
+    const status = form.querySelector('.status-indicator');
+    const loadTrailsOptions = async () => {
+      if (!trailSelect) return;
+      if (status) status.dataset.state = 'loading';
+      try {
+        const filters = new URLSearchParams();
+        const stateField = form.querySelector('[name="estadoFiltro"]');
+        const cityField = form.querySelector('[name="cidadeFiltro"]');
+        const nameField = form.querySelector('[name="nomeFiltro"]');
+        if (stateField?.value) filters.set('estado', stateField.value);
+        if (cityField?.value) filters.set('cidade', cityField.value);
+        if (nameField?.value) filters.set('nome', nameField.value);
+        const data = await fetchJSON(`/api/trails?${filters.toString()}&limit=50`);
+        const trails = data?.data || data?.results || [];
+        trailSelect.innerHTML = '<option value="" disabled selected>Selecione uma trilha</option>';
+        trails.forEach((trail) => {
+          const option = document.createElement('option');
+          option.value = trail.id;
+          option.textContent = `${trail.nome} — ${trail.cidade}/${trail.estado}`;
+          trailSelect.appendChild(option);
+        });
+        if (status) status.dataset.state = trails.length ? 'ready' : 'empty';
+      } catch (error) {
+        console.error(error);
+        if (status) status.dataset.state = 'error';
+      }
+    };
+
+    form.querySelectorAll('[data-trail-filter]').forEach((input) => {
+      input.addEventListener('change', loadTrailsOptions);
+    });
+
+    loadTrailsOptions();
+
+    form.addEventListener('submit', async (event) => {
+      event.preventDefault();
+      if (!trailSelect?.value) {
+        alert('Selecione uma trilha válida.');
+        return;
+      }
+      const payload = Object.fromEntries(new FormData(form).entries());
+      try {
+        await fetchJSON('/api/expeditions', {
+          method: 'POST',
+          body: JSON.stringify(payload),
+        });
+        alert('Expedição criada com sucesso!');
+        form.reset();
+        loadTrailsOptions();
+      } catch (error) {
+        alert('Erro ao criar expedição. Verifique se sua conta está ativada como guia CADASTUR.');
+      }
+    });
+  };
+
+  const initExpeditionsList = () => {
+    const list = document.querySelector(selectors.expeditionsList);
+    if (!list) return;
+    const form = document.querySelector('#expeditionFilters');
+    const pagination = document.querySelector('#expeditionPagination');
+
+    const applyFilters = () => {
+      if (!form) return;
+      const params = parseQuery();
+      Array.from(form.elements).forEach((field) => {
+        if (!(field instanceof HTMLInputElement || field instanceof HTMLSelectElement)) return;
+        if (!field.name) return;
+        field.value = params[field.name] || '';
+      });
+    };
+
+    const buildQuery = () => {
+      const params = new URLSearchParams();
+      if (!form) return params;
+      Array.from(form.elements).forEach((field) => {
+        if (!(field instanceof HTMLInputElement || field instanceof HTMLSelectElement)) return;
+        if (!field.name || !field.value) return;
+        params.set(field.name, field.value);
+      });
+      if (!params.get('limit')) params.set('limit', '20');
+      if (!params.get('page')) params.set('page', '1');
+      return params;
+    };
+
+    const loadExpeditions = async () => {
+      updateDataState(list, 'loading');
+      const params = buildQuery();
+      try {
+        const data = await fetchJSON(`/api/expeditions?${params.toString()}`);
+        const expeditions = data?.data || data?.results || [];
+        const meta = data?.meta || { page: Number(params.get('page')), totalPages: 1 };
+        list.innerHTML = '';
+        if (!expeditions.length) {
+          updateDataState(list, 'empty');
+        } else {
+          expeditions.forEach((expedition) => list.appendChild(renderExpeditionCard(expedition)));
+          updateDataState(list, 'ready');
+        }
+        if (pagination) {
+          renderPagination({
+            container: pagination,
+            meta: {
+              page: meta.page,
+              totalPages: meta.totalPages || Math.ceil((meta.total || expeditions.length) / (meta.perPage || 20)) || 1,
+            },
+            onPageChange: (page) => {
+              updateQuery({ page });
+              params.set('page', String(page));
+              window.scrollTo({ top: 0, behavior: 'smooth' });
+              loadExpeditions();
+            },
+          });
+        }
+      } catch (error) {
+        console.error(error);
+        updateDataState(list, 'error');
+      }
+    };
+
+    applyFilters();
+
+    if (form) {
+      form.addEventListener('submit', (event) => {
+        event.preventDefault();
+        const params = buildQuery();
+        updateQuery(Object.fromEntries(params.entries()));
+        loadExpeditions();
+      });
+    }
+
+    window.addEventListener('popstate', () => {
+      applyFilters();
+      loadExpeditions();
+    });
+
+    loadExpeditions();
+  };
+
+  const initAuthForms = () => {
+    const loginForm = document.querySelector('#loginForm');
+    if (loginForm) {
+      loginForm.addEventListener('submit', async (event) => {
+        event.preventDefault();
+        const payload = Object.fromEntries(new FormData(loginForm).entries());
+        try {
+          await fetchJSON('/api/auth/login', {
+            method: 'POST',
+            body: JSON.stringify(payload),
+          });
+          window.location.href = '/';
+        } catch (error) {
+          alert('Não foi possível entrar. Verifique suas credenciais.');
+        }
+      });
+    }
+
+    const signupForm = document.querySelector('#signupForm');
+    if (signupForm) {
+      signupForm.addEventListener('submit', async (event) => {
+        event.preventDefault();
+        const payload = Object.fromEntries(new FormData(signupForm).entries());
+        try {
+          await fetchJSON('/api/auth/signup', {
+            method: 'POST',
+            body: JSON.stringify(payload),
+          });
+          window.location.href = '/login.html?signup=success';
+        } catch (error) {
+          alert('Erro ao criar conta. Verifique os dados informados.');
+        }
+      });
+    }
+  };
+
+  const initGuideActivation = () => {
+    const activationForm = document.querySelector('#activationForm');
+    if (!activationForm) return;
+    activationForm.addEventListener('submit', async (event) => {
+      event.preventDefault();
+      const payload = Object.fromEntries(new FormData(activationForm).entries());
+      try {
+        await fetchJSON('/api/auth/activate-guide', {
+          method: 'POST',
+          body: JSON.stringify(payload),
+        });
+        alert('Conta de guia ativada com sucesso!');
+        window.location.reload();
+      } catch (error) {
+        alert('Erro ao ativar guia. Confira seus dados CADASTUR.');
+      }
+    });
+  };
+
+  const initAdminForms = () => {
+    const cadasturForm = document.querySelector('#cadasturUploadForm');
+    if (cadasturForm) {
+      cadasturForm.addEventListener('submit', async (event) => {
+        event.preventDefault();
+        const fileInput = cadasturForm.querySelector('input[type="file"]');
+        if (!fileInput?.files?.length) {
+          alert('Selecione um arquivo CSV.');
+          return;
+        }
+        const formData = new FormData();
+        formData.append('file', fileInput.files[0]);
+        try {
+          await fetch('/api/admin/cadastur', {
+            method: 'POST',
+            body: formData,
+          });
+          alert('Base CADASTUR atualizada!');
+        } catch (error) {
+          alert('Erro ao enviar CSV.');
+        }
+      });
+    }
+  };
+
+  const initAnalytics = () => {
+    if (!document.querySelector('script[data-gtag]')) {
+      const gtagScript = document.createElement('script');
+      gtagScript.src = 'https://www.googletagmanager.com/gtag/js?id=G-XXXXXXX';
+      gtagScript.async = true;
+      gtagScript.setAttribute('data-gtag', 'true');
+      gtagScript.crossOrigin = 'anonymous';
+      document.head.appendChild(gtagScript);
+    }
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){window.dataLayer.push(arguments);}
+    gtag('consent', 'default', {
+      ad_storage: 'denied',
+      analytics_storage: 'granted',
+    });
+    gtag('js', new Date());
+    gtag('config', 'G-XXXXXXX');
+
+    document.querySelectorAll('[data-analytics="cta"]').forEach((element) => {
+      element.addEventListener('click', () => {
+        gtag('event', 'cta_click', {
+          event_category: element.dataset.category || 'cta',
+          event_label: element.textContent.trim(),
+        });
+      });
+    });
+
+    document.querySelectorAll('form[data-analytics="filter"]').forEach((form) => {
+      form.addEventListener('submit', () => {
+        gtag('event', 'filter_submit', {
+          event_category: form.dataset.category || 'filter',
+          event_label: window.location.pathname,
+        });
+      });
+    });
+  };
+
+  document.addEventListener('DOMContentLoaded', () => {
+    initNav();
+    initSearchAutocomplete();
+    initHighlights();
+    initTrailsList();
+    initTrailDetails();
+    initCommentForm();
+    initGuidesList();
+    initGuideProfile();
+    initExpeditionForm();
+    initExpeditionsList();
+    initAuthForms();
+    initGuideActivation();
+    initAdminForms();
+    initAnalytics();
+  });
+})();

--- a/blog.html
+++ b/blog.html
@@ -1,0 +1,61 @@
+<!doctype html>
+<html lang="pt-BR">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>Blog Trekko</title>
+  <meta name="description" content="Conteúdo sobre trilhas, segurança e bastidores do turismo de aventura no Brasil." />
+  <link rel="canonical" href="https://www.trekko.com.br/blog.html" />
+  <link rel="preload" href="/assets/css/main.css" as="style" />
+  <link rel="stylesheet" href="/assets/css/main.css" />
+</head>
+<body>
+<a class="skip-link" href="#conteudo">Pular para o conteúdo</a>
+<header class="site-header">
+  <nav class="nav" aria-label="Principal">
+    <a class="nav__logo" href="/">Trekko</a>
+    <button class="nav__toggle" type="button" aria-expanded="false" aria-controls="menu">Menu</button>
+    <ul id="menu" class="nav__menu" data-state="closed">
+      <li><a href="/trilhas.html">Trilhas</a></li>
+      <li><a href="/guias.html">Guias CADASTUR</a></li>
+      <li><a href="/expedicoes.html">Expedições</a></li>
+      <li><a href="/login.html" class="button button--ghost">Entrar</a></li>
+    </ul>
+  </nav>
+</header>
+<main id="conteudo" class="section">
+  <header class="section__header">
+    <div>
+      <h1 class="section__title">Blog Trekko</h1>
+      <p class="section__description">Artigos sobre segurança, equipamentos e guias certificados.</p>
+    </div>
+  </header>
+
+  <div class="cards" data-state="ready">
+    <article class="card">
+      <div class="card__body">
+        <h2 class="card__title"><a href="/blog/checklist-equipamentos.html">Checklist de equipamentos para travessias</a></h2>
+        <p class="card__meta">Atualizado em 02/01/2024</p>
+        <p>Organize a mochila ideal para travessias com grande desnível e clima variável.</p>
+      </div>
+    </article>
+    <article class="card">
+      <div class="card__body">
+        <h2 class="card__title"><a href="/blog/cadastur.html">Por que contratar guias CADASTUR</a></h2>
+        <p class="card__meta">Atualizado em 15/12/2023</p>
+        <p>Entenda os critérios de certificação e como validar a credencial de um guia.</p>
+      </div>
+    </article>
+  </div>
+</main>
+<footer class="site-footer">
+  <nav aria-label="Rodapé">
+    <a href="/sobre.html">Sobre</a>
+    <a href="/contato.html">Contato</a>
+    <a href="/politica.html">Política e Termos</a>
+  </nav>
+  <small>© Trekko</small>
+</footer>
+<script src="/assets/js/main.js" defer></script>
+</body>
+</html>

--- a/blog/cadastur.html
+++ b/blog/cadastur.html
@@ -1,0 +1,56 @@
+<!doctype html>
+<html lang="pt-BR">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>Como validar um guia CADASTUR — Trekko</title>
+  <meta name="description" content="Confira os passos para verificar se um guia é certificado pelo Ministério do Turismo." />
+  <link rel="canonical" href="https://www.trekko.com.br/blog/cadastur.html" />
+  <link rel="preload" href="/assets/css/main.css" as="style" />
+  <link rel="stylesheet" href="/assets/css/main.css" />
+</head>
+<body>
+<a class="skip-link" href="#conteudo">Pular para o conteúdo</a>
+<header class="site-header">
+  <nav class="nav" aria-label="Principal">
+    <a class="nav__logo" href="/">Trekko</a>
+    <button class="nav__toggle" type="button" aria-expanded="false" aria-controls="menu">Menu</button>
+    <ul id="menu" class="nav__menu" data-state="closed">
+      <li><a href="/trilhas.html">Trilhas</a></li>
+      <li><a href="/guias.html">Guias CADASTUR</a></li>
+      <li><a href="/expedicoes.html">Expedições</a></li>
+      <li><a href="/login.html" class="button button--ghost">Entrar</a></li>
+    </ul>
+  </nav>
+</header>
+<main id="conteudo" class="section">
+  <header class="section__header">
+    <div>
+      <h1 class="section__title">Como validar um guia CADASTUR</h1>
+      <p class="section__description">Atualizado em <time datetime="2023-12-15">15/12/2023</time></p>
+    </div>
+  </header>
+  <article class="card">
+    <div class="card__body">
+      <p>O CADASTUR é o cadastro oficial do Ministério do Turismo para prestadores de serviços. Para validar um guia:</p>
+      <ol class="list">
+        <li>Acesse o portal oficial do CADASTUR.</li>
+        <li>Informe o número de registro ou o nome completo.</li>
+        <li>Confira se o status está ativo e a validade do credenciamento.</li>
+        <li>Verifique os contatos oficiais e compare com os dados informados na Trekko.</li>
+      </ol>
+      <p>Na Trekko, o vínculo é feito automaticamente após o guia comprovar a titularidade por e-mail, telefone ou código de ativação fornecido pelo administrador.</p>
+    </div>
+  </article>
+</main>
+<footer class="site-footer">
+  <nav aria-label="Rodapé">
+    <a href="/sobre.html">Sobre</a>
+    <a href="/contato.html">Contato</a>
+    <a href="/politica.html">Política e Termos</a>
+  </nav>
+  <small>© Trekko</small>
+</footer>
+<script src="/assets/js/main.js" defer></script>
+</body>
+</html>

--- a/blog/checklist-equipamentos.html
+++ b/blog/checklist-equipamentos.html
@@ -1,0 +1,57 @@
+<!doctype html>
+<html lang="pt-BR">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>Checklist de equipamentos para travessias — Trekko</title>
+  <meta name="description" content="Saiba como montar uma mochila equilibrada para travessias de montanha com segurança." />
+  <link rel="canonical" href="https://www.trekko.com.br/blog/checklist-equipamentos.html" />
+  <link rel="preload" href="/assets/css/main.css" as="style" />
+  <link rel="stylesheet" href="/assets/css/main.css" />
+  <article itemscope itemtype="https://schema.org/BlogPosting"></article>
+</head>
+<body>
+<a class="skip-link" href="#conteudo">Pular para o conteúdo</a>
+<header class="site-header">
+  <nav class="nav" aria-label="Principal">
+    <a class="nav__logo" href="/">Trekko</a>
+    <button class="nav__toggle" type="button" aria-expanded="false" aria-controls="menu">Menu</button>
+    <ul id="menu" class="nav__menu" data-state="closed">
+      <li><a href="/trilhas.html">Trilhas</a></li>
+      <li><a href="/guias.html">Guias CADASTUR</a></li>
+      <li><a href="/expedicoes.html">Expedições</a></li>
+      <li><a href="/login.html" class="button button--ghost">Entrar</a></li>
+    </ul>
+  </nav>
+</header>
+<main id="conteudo" class="section" itemscope itemtype="https://schema.org/BlogPosting">
+  <header class="section__header">
+    <div>
+      <h1 class="section__title" itemprop="headline">Checklist de equipamentos para travessias</h1>
+      <p class="section__description">Atualizado em <time datetime="2024-01-02" itemprop="dateModified">02/01/2024</time></p>
+    </div>
+  </header>
+  <article class="card" itemprop="articleBody">
+    <div class="card__body">
+      <p>Montar uma mochila equilibrada é essencial para percorrer travessias longas com conforto e segurança. Siga as categorias abaixo:</p>
+      <ul class="list">
+        <li><strong>Vestimenta:</strong> segunda pele térmica, jaqueta impermeável, meias de trilha.</li>
+        <li><strong>Acampamento:</strong> barraca 4 estações, saco de dormir compatível com a temperatura mínima, isolante térmico.</li>
+        <li><strong>Alimentação:</strong> refeições liofilizadas, snacks energéticos, fogareiro e cartucho.</li>
+        <li><strong>Segurança:</strong> kit de primeiros socorros, manta térmica, GPS ou mapa impresso.</li>
+      </ul>
+      <p>Faça o balanceamento da carga para manter o centro de gravidade próximo às costas e ajuste as alças antes de iniciar a trilha.</p>
+    </div>
+  </article>
+</main>
+<footer class="site-footer">
+  <nav aria-label="Rodapé">
+    <a href="/sobre.html">Sobre</a>
+    <a href="/contato.html">Contato</a>
+    <a href="/politica.html">Política e Termos</a>
+  </nav>
+  <small>© Trekko</small>
+</footer>
+<script src="/assets/js/main.js" defer></script>
+</body>
+</html>

--- a/contato.html
+++ b/contato.html
@@ -1,0 +1,85 @@
+<!doctype html>
+<html lang="pt-BR">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>Contato — Trekko</title>
+  <meta name="description" content="Fale com a equipe Trekko para parcerias, suporte ou dúvidas sobre trilhas e expedições." />
+  <link rel="canonical" href="https://www.trekko.com.br/contato.html" />
+  <link rel="preload" href="/assets/css/main.css" as="style" />
+  <link rel="stylesheet" href="/assets/css/main.css" />
+</head>
+<body>
+<a class="skip-link" href="#conteudo">Pular para o conteúdo</a>
+<header class="site-header">
+  <nav class="nav" aria-label="Principal">
+    <a class="nav__logo" href="/">Trekko</a>
+    <button class="nav__toggle" type="button" aria-expanded="false" aria-controls="menu">Menu</button>
+    <ul id="menu" class="nav__menu" data-state="closed">
+      <li><a href="/trilhas.html">Trilhas</a></li>
+      <li><a href="/guias.html">Guias CADASTUR</a></li>
+      <li><a href="/expedicoes.html">Expedições</a></li>
+      <li><a href="/login.html" class="button button--ghost">Entrar</a></li>
+    </ul>
+  </nav>
+</header>
+<main id="conteudo" class="section">
+  <header class="section__header">
+    <div>
+      <h1 class="section__title">Contato</h1>
+      <p class="section__description">Envie sua mensagem para suporte, parcerias ou sugestões.</p>
+    </div>
+  </header>
+
+  <section class="section" aria-labelledby="formulario">
+    <h2 id="formulario" class="section__title">Fale com a Trekko</h2>
+    <form class="form" action="https://formspree.io/f/trekko" method="post">
+      <div class="form__group">
+        <label for="assunto">Assunto</label>
+        <select id="assunto" name="assunto" required>
+          <option value="">Selecione</option>
+          <option>Suporte</option>
+          <option>Parcerias</option>
+          <option>Problemas com expedição</option>
+          <option>Outros</option>
+        </select>
+      </div>
+      <div class="form__group">
+        <label for="nome">Nome</label>
+        <input id="nome" name="nome" type="text" required />
+      </div>
+      <div class="form__group">
+        <label for="email">E-mail</label>
+        <input id="email" name="email" type="email" required />
+      </div>
+      <div class="form__group">
+        <label for="mensagem">Mensagem</label>
+        <textarea id="mensagem" name="mensagem" rows="5" required></textarea>
+      </div>
+      <div class="form__actions">
+        <button class="button button--primary" type="submit">Enviar</button>
+        <p class="muted">Tempo médio de resposta: 2 dias úteis.</p>
+      </div>
+    </form>
+  </section>
+
+  <section class="section" aria-labelledby="canais">
+    <h2 id="canais" class="section__title">Canais oficiais</h2>
+    <ul class="list">
+      <li>E-mail: <a href="mailto:contato@trekko.com.br">contato@trekko.com.br</a></li>
+      <li>WhatsApp: <a href="https://wa.me/5511999999999" rel="noopener">(11) 99999-9999</a></li>
+      <li>Endereço: Rua das Trilhas, 123 — São Paulo/SP</li>
+    </ul>
+  </section>
+</main>
+<footer class="site-footer">
+  <nav aria-label="Rodapé">
+    <a href="/sobre.html">Sobre</a>
+    <a href="/contato.html" aria-current="page">Contato</a>
+    <a href="/politica.html">Política e Termos</a>
+  </nav>
+  <small>© Trekko</small>
+</footer>
+<script src="/assets/js/main.js" defer></script>
+</body>
+</html>

--- a/criar-expedicao.html
+++ b/criar-expedicao.html
@@ -1,0 +1,98 @@
+<!doctype html>
+<html lang="pt-BR">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>Criar expedição — Trekko</title>
+  <meta name="description" content="Publique expedições vinculadas a trilhas oficiais e controle vagas, preço e datas." />
+  <link rel="canonical" href="https://www.trekko.com.br/criar-expedicao.html" />
+  <link rel="preload" href="/assets/css/main.css" as="style" />
+  <link rel="stylesheet" href="/assets/css/main.css" />
+  <meta property="og:title" content="Criar expedição — Trekko" />
+  <meta property="og:type" content="website" />
+  <meta property="og:description" content="Ferramenta exclusiva para guias CADASTUR ativados organizarem suas expedições." />
+</head>
+<body>
+<a class="skip-link" href="#conteudo">Pular para o conteúdo</a>
+<header class="site-header">
+  <nav class="nav" aria-label="Principal">
+    <a class="nav__logo" href="/">Trekko</a>
+    <button class="nav__toggle" type="button" aria-expanded="false" aria-controls="menu">Menu</button>
+    <ul id="menu" class="nav__menu" data-state="closed">
+      <li><a href="/trilhas.html">Trilhas</a></li>
+      <li><a href="/guias.html">Guias CADASTUR</a></li>
+      <li><a href="/expedicoes.html">Expedições</a></li>
+      <li><a href="/login.html" class="button button--primary">Entrar</a></li>
+    </ul>
+  </nav>
+</header>
+<main id="conteudo" class="section">
+  <header class="section__header">
+    <div>
+      <h1 class="section__title">Cadastrar nova expedição</h1>
+      <p class="section__description">Somente guias com conta ativada podem publicar expedições. Todas as informações são obrigatórias.</p>
+    </div>
+    <p class="status-indicator" data-state="loading">Sincronizando trilhas disponíveis</p>
+  </header>
+
+  <form class="form" id="expeditionForm" aria-label="Formulário de criação de expedição">
+    <fieldset class="details-grid__item">
+      <legend>Filtrar trilhas</legend>
+      <div class="grid grid--two">
+        <label>Estado
+          <input type="text" name="estadoFiltro" placeholder="UF" maxlength="2" data-trail-filter />
+        </label>
+        <label>Cidade
+          <input type="text" name="cidadeFiltro" placeholder="Cidade" data-trail-filter />
+        </label>
+        <label>Nome da trilha
+          <input type="text" name="nomeFiltro" placeholder="Nome" data-trail-filter />
+        </label>
+      </div>
+    </fieldset>
+
+    <div class="form__group">
+      <label for="trailId">Trilha</label>
+      <select id="trailId" name="trailId" required></select>
+    </div>
+
+    <div class="grid grid--two">
+      <label for="inicio">Data de início
+        <input id="inicio" name="inicio" type="text" inputmode="numeric" pattern="\\d{2}/\\d{2}/\\d{4}" placeholder="dd/mm/aaaa" required />
+      </label>
+      <label for="fim">Data de término
+        <input id="fim" name="fim" type="text" inputmode="numeric" pattern="\\d{2}/\\d{2}/\\d{4}" placeholder="dd/mm/aaaa" required />
+      </label>
+    </div>
+
+    <div class="grid grid--two">
+      <label for="precoPorPessoa">Preço por pessoa (R$)
+        <input id="precoPorPessoa" name="precoPorPessoa" type="number" min="0" step="0.01" required />
+      </label>
+      <label for="vagas">Vagas disponíveis
+        <input id="vagas" name="vagas" type="number" min="1" step="1" required />
+      </label>
+    </div>
+
+    <div class="form__group">
+      <label for="descricao">Descrição detalhada</label>
+      <textarea id="descricao" name="descricao" rows="5" required placeholder="Inclua logística, equipamentos obrigatórios e política de cancelamento."></textarea>
+    </div>
+
+    <div class="form__actions">
+      <button class="button button--primary" type="submit" data-analytics="cta" data-category="expedition">Publicar expedição</button>
+      <p class="muted">Ao publicar você concorda com os Termos Trekko.</p>
+    </div>
+  </form>
+</main>
+<footer class="site-footer">
+  <nav aria-label="Rodapé">
+    <a href="/sobre.html">Sobre</a>
+    <a href="/contato.html">Contato</a>
+    <a href="/politica.html">Política e Termos</a>
+  </nav>
+  <small>© Trekko</small>
+</footer>
+<script src="/assets/js/main.js" defer></script>
+</body>
+</html>

--- a/expedicoes.html
+++ b/expedicoes.html
@@ -1,0 +1,61 @@
+<!doctype html>
+<html lang="pt-BR">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>Expedições em trilhas brasileiras — Trekko</title>
+  <meta name="description" content="Pesquise expedições cadastradas pelos guias CADASTUR com datas e vagas atualizadas." />
+  <link rel="canonical" href="https://www.trekko.com.br/expedicoes.html" />
+  <link rel="preload" href="/assets/css/main.css" as="style" />
+  <link rel="stylesheet" href="/assets/css/main.css" />
+  <meta property="og:title" content="Expedições em trilhas brasileiras — Trekko" />
+  <meta property="og:type" content="website" />
+  <meta property="og:description" content="Expedições reais cadastradas pelos guias ativos da plataforma." />
+</head>
+<body>
+<a class="skip-link" href="#conteudo">Pular para o conteúdo</a>
+<header class="site-header">
+  <nav class="nav" aria-label="Principal">
+    <a class="nav__logo" href="/">Trekko</a>
+    <button class="nav__toggle" type="button" aria-expanded="false" aria-controls="menu">Menu</button>
+    <ul id="menu" class="nav__menu" data-state="closed">
+      <li><a href="/trilhas.html">Trilhas</a></li>
+      <li><a href="/guias.html">Guias CADASTUR</a></li>
+      <li><a href="/expedicoes.html" aria-current="page">Expedições</a></li>
+      <li><a href="/login.html" class="button button--primary">Entrar</a></li>
+    </ul>
+  </nav>
+</header>
+<main id="conteudo" class="section">
+  <header class="section__header">
+    <div>
+      <h1 class="section__title">Expedições disponíveis</h1>
+      <p class="section__description">Somente expedições criadas na plataforma pelos guias ativos são exibidas aqui.</p>
+    </div>
+    <a class="button button--ghost" href="/criar-expedicao.html">Criar expedição</a>
+  </header>
+
+  <form class="filters" id="expeditionFilters" aria-label="Filtros de expedições" method="get" data-analytics="filter" data-category="expedition_filters">
+    <input type="search" name="trailId" placeholder="ID da trilha" aria-label="ID da trilha" />
+    <input type="search" name="estado" placeholder="Estado (UF)" aria-label="Estado" />
+    <input type="search" name="cidade" placeholder="Cidade" aria-label="Cidade" />
+    <input type="text" name="from" placeholder="Data inicial (dd/mm/aaaa)" aria-label="Data inicial" pattern="\\d{2}/\\d{2}/\\d{4}" />
+    <input type="hidden" name="limit" value="20" />
+    <input type="hidden" name="page" value="1" />
+    <button class="button button--primary" type="submit" data-analytics="cta" data-category="expedition_filters">Aplicar filtros</button>
+  </form>
+
+  <div class="grid" id="expeditionsList" data-state="loading" aria-live="polite"></div>
+  <nav class="pagination" id="expeditionPagination" role="navigation" aria-label="Paginação de expedições"></nav>
+</main>
+<footer class="site-footer">
+  <nav aria-label="Rodapé">
+    <a href="/sobre.html">Sobre</a>
+    <a href="/contato.html">Contato</a>
+    <a href="/politica.html">Política e Termos</a>
+  </nav>
+  <small>© Trekko</small>
+</footer>
+<script src="/assets/js/main.js" defer></script>
+</body>
+</html>

--- a/guia.html
+++ b/guia.html
@@ -1,0 +1,71 @@
+<!doctype html>
+<html lang="pt-BR">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>Perfil do guia — Trekko</title>
+  <meta name="description" content="Veja informações completas do guia CADASTUR, contatos e expedições disponíveis." />
+  <link rel="canonical" href="https://www.trekko.com.br/guia.html" />
+  <link rel="preload" href="/assets/css/main.css" as="style" />
+  <link rel="stylesheet" href="/assets/css/main.css" />
+  <meta property="og:title" content="Perfil do guia — Trekko" />
+  <meta property="og:type" content="profile" />
+  <meta property="og:description" content="Confirme a certificação CADASTUR e agende expedições diretamente com o guia." />
+  <meta property="og:image" content="https://cdn.trekko.com/og-guia.jpg" />
+  <script type="application/ld+json" id="guideSchema">{"@context":"https://schema.org","@type":"Person"}</script>
+</head>
+<body>
+<a class="skip-link" href="#principal">Pular para o conteúdo</a>
+<header class="site-header">
+  <nav class="nav" aria-label="Principal">
+    <a class="nav__logo" href="/">Trekko</a>
+    <button class="nav__toggle" type="button" aria-expanded="false" aria-controls="menu">Menu</button>
+    <ul id="menu" class="nav__menu" data-state="closed">
+      <li><a href="/trilhas.html">Trilhas</a></li>
+      <li><a href="/guias.html">Guias CADASTUR</a></li>
+      <li><a href="/expedicoes.html">Expedições</a></li>
+      <li><a href="/login.html" class="button button--primary">Entrar</a></li>
+    </ul>
+  </nav>
+</header>
+<main id="principal" class="section" data-guide-profile>
+  <header class="profile-header">
+    <img class="profile-header__photo" src="https://images.unsplash.com/photo-1544723795-3fb6469f5b39?auto=format&fit=crop&w=320&q=80" alt="Foto do guia" loading="lazy" width="160" height="160" data-guide-photo />
+    <div class="profile-header__info">
+      <h1 data-guide-name>Guia</h1>
+      <p>CADASTUR: <strong data-guide-cadastur>—</strong></p>
+      <p class="muted" data-guide-city></p>
+      <div class="card__actions">
+        <a class="button button--primary" data-guide-whatsapp href="https://wa.me/55" target="_blank" rel="noopener" data-analytics="cta" data-category="guide">WhatsApp</a>
+      </div>
+    </div>
+  </header>
+
+  <section class="section" aria-labelledby="sobre">
+    <h2 id="sobre" class="section__title">Sobre o guia</h2>
+    <p data-guide-bio>Carregando informações...</p>
+    <h3>Contatos</h3>
+    <ul class="list" data-guide-contacts></ul>
+  </section>
+
+  <section class="section" aria-labelledby="expedicoes-guia">
+    <div class="section__header">
+      <h2 id="expedicoes-guia" class="section__title">Expedições publicadas</h2>
+      <a class="button button--ghost" href="/criar-expedicao.html" data-analytics="cta" data-category="guide">Criar expedição</a>
+    </div>
+    <div id="guideExpeditions" class="grid" data-state="loading" aria-live="polite"></div>
+  </section>
+
+  <p class="status-indicator" data-state="loading">Carregando perfil</p>
+</main>
+<footer class="site-footer">
+  <nav aria-label="Rodapé">
+    <a href="/sobre.html">Sobre</a>
+    <a href="/contato.html">Contato</a>
+    <a href="/politica.html">Política e Termos</a>
+  </nav>
+  <small>© Trekko</small>
+</footer>
+<script src="/assets/js/main.js" defer></script>
+</body>
+</html>

--- a/guias.html
+++ b/guias.html
@@ -1,0 +1,92 @@
+<!doctype html>
+<html lang="pt-BR">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>Guias CADASTUR certificados — Trekko</title>
+  <meta name="description" content="Encontre guias turísticos cadastrados no CADASTUR por UF, cidade ou número de registro e ative o contato direto." />
+  <link rel="canonical" href="https://www.trekko.com.br/guias.html" />
+  <link rel="preload" href="/assets/css/main.css" as="style" />
+  <link rel="stylesheet" href="/assets/css/main.css" />
+  <meta property="og:title" content="Guias CADASTUR certificados — Trekko" />
+  <meta property="og:type" content="website" />
+  <meta property="og:description" content="Lista oficial integrada à base CADASTUR com filtros por localização." />
+  <meta property="og:image" content="https://cdn.trekko.com/og-guias.jpg" />
+  <meta name="twitter:card" content="summary_large_image" />
+</head>
+<body>
+<a class="skip-link" href="#content">Pular para o conteúdo</a>
+<header class="site-header">
+  <nav class="nav" aria-label="Principal">
+    <a class="nav__logo" href="/">Trekko</a>
+    <button class="nav__toggle" type="button" aria-expanded="false" aria-controls="menu">Menu</button>
+    <ul id="menu" class="nav__menu" data-state="closed">
+      <li><a href="/trilhas.html">Trilhas</a></li>
+      <li><a href="/guias.html" aria-current="page">Guias CADASTUR</a></li>
+      <li><a href="/expedicoes.html">Expedições</a></li>
+      <li><a href="/login.html" class="button button--primary">Entrar</a></li>
+    </ul>
+  </nav>
+</header>
+<main id="content" class="section">
+  <header class="section__header">
+    <div>
+      <h1 class="section__title">Guias certificados</h1>
+      <p class="section__description">Integração completa com o banco CADASTUR. Atualizado diariamente.</p>
+    </div>
+    <p class="muted">Última atualização do CADASTUR: <span id="cadasturUpdatedAt">—</span></p>
+  </header>
+
+  <form class="filters" id="guideFilters" aria-label="Filtros de guias" method="get" data-analytics="filter" data-category="guide_filters">
+    <select name="uf" aria-label="Estado">
+      <option value="">UF</option>
+      <option value="AC">AC</option>
+      <option value="AL">AL</option>
+      <option value="AM">AM</option>
+      <option value="AP">AP</option>
+      <option value="BA">BA</option>
+      <option value="CE">CE</option>
+      <option value="DF">DF</option>
+      <option value="ES">ES</option>
+      <option value="GO">GO</option>
+      <option value="MA">MA</option>
+      <option value="MG">MG</option>
+      <option value="MS">MS</option>
+      <option value="MT">MT</option>
+      <option value="PA">PA</option>
+      <option value="PB">PB</option>
+      <option value="PE">PE</option>
+      <option value="PI">PI</option>
+      <option value="PR">PR</option>
+      <option value="RJ">RJ</option>
+      <option value="RN">RN</option>
+      <option value="RO">RO</option>
+      <option value="RR">RR</option>
+      <option value="RS">RS</option>
+      <option value="SC">SC</option>
+      <option value="SE">SE</option>
+      <option value="SP">SP</option>
+      <option value="TO">TO</option>
+    </select>
+    <input type="search" name="cidade" placeholder="Cidade" aria-label="Cidade" />
+    <input type="search" name="nome" placeholder="Nome" aria-label="Nome" />
+    <input type="search" name="cadastur" placeholder="Nº CADASTUR" aria-label="Nº CADASTUR" />
+    <input type="hidden" name="limit" value="30" />
+    <input type="hidden" name="page" value="1" />
+    <button class="button button--primary" type="submit" data-analytics="cta" data-category="guide_filters">Filtrar</button>
+  </form>
+
+  <div class="cards" id="guidesList" data-state="loading" aria-live="polite" aria-busy="true"></div>
+  <nav class="pagination" id="guidePagination" role="navigation" aria-label="Paginação de guias"></nav>
+</main>
+<footer class="site-footer">
+  <nav aria-label="Rodapé">
+    <a href="/sobre.html">Sobre</a>
+    <a href="/contato.html">Contato</a>
+    <a href="/politica.html">Política e Termos</a>
+  </nav>
+  <small>© Trekko</small>
+</footer>
+<script src="/assets/js/main.js" defer></script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,157 @@
+<!doctype html>
+<html lang="pt-BR">
+<head>
+  <meta charset="utf-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>Trekko — Trilhas, Guias CADASTUR e Expedições</title>
+  <meta name="description" content="Encontre trilhas reais no Brasil, guias certificados pelo CADASTUR e expedições organizadas com segurança." />
+  <link rel="canonical" href="https://www.trekko.com.br/" />
+  <link rel="preconnect" href="https://cdn.trekko.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link rel="preload" href="/assets/css/main.css" as="style" />
+  <link rel="stylesheet" href="/assets/css/main.css" />
+  <meta property="og:title" content="Trekko — Trilhas, Guias CADASTUR e Expedições" />
+  <meta property="og:description" content="A plataforma brasileira para trilhas certificadas, guias e expedições." />
+  <meta property="og:url" content="https://www.trekko.com.br/" />
+  <meta property="og:type" content="website" />
+  <meta property="og:image" content="https://cdn.trekko.com/og.jpg" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Trekko — Trilhas, Guias CADASTUR e Expedições" />
+  <meta name="twitter:description" content="Busque trilhas, encontre guias certificados e agende expedições pelo Brasil." />
+  <meta name="twitter:image" content="https://cdn.trekko.com/og.jpg" />
+  <meta name="theme-color" content="#2D6A4F" />
+  <style>
+    body{margin:0;font-family:"Outfit","Sora",sans-serif;color:#333;background:#f6f6f4}
+    .nav__menu[data-state="closed"],.skip-link{position:absolute;top:-100px;left:0}
+    .skip-link:focus{top:0}
+  </style>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "WebSite",
+    "name": "Trekko",
+    "url": "https://www.trekko.com.br/",
+    "potentialAction": {
+      "@type": "SearchAction",
+      "target": "https://www.trekko.com.br/trilhas.html?q={search_term_string}",
+      "query-input": "required name=search_term_string"
+    }
+  }
+  </script>
+</head>
+<body>
+<a class="skip-link" href="#content">Pular para o conteúdo</a>
+<header class="site-header">
+  <div class="alert-banner" role="status">Plataforma em beta. Dados oficiais CADASTUR e ICMBio atualizados diariamente.</div>
+  <nav class="nav" aria-label="Principal">
+    <a class="nav__logo" href="/">Trekko</a>
+    <button class="nav__toggle" type="button" aria-expanded="false" aria-controls="menu">Menu</button>
+    <ul id="menu" class="nav__menu" data-state="closed">
+      <li><a href="/trilhas.html">Trilhas</a></li>
+      <li><a href="/guias.html">Guias CADASTUR</a></li>
+      <li><a href="/expedicoes.html">Expedições</a></li>
+      <li><a href="/sobre.html">Sobre</a></li>
+      <li><a href="/login.html" class="button button--primary">Entrar</a></li>
+    </ul>
+  </nav>
+</header>
+<main id="content">
+  <section class="hero" role="search" aria-label="Busca por trilhas">
+    <div class="section__header">
+      <div>
+        <h1 class="hero__title">Encontre sua próxima trilha ⛰️</h1>
+        <p class="hero__subtitle">Busque por trilhas homologadas, guias certificados e expedições com disponibilidade real no Brasil inteiro.</p>
+      </div>
+    </div>
+    <form class="search-bar" id="searchForm" action="/trilhas.html" method="get" data-analytics="filter" data-category="home_search">
+      <div class="search-bar__group">
+        <label for="q">Trilha, Parque, Cidade ou Estado</label>
+        <input id="q" name="q" class="search-bar__field" type="search" placeholder="Ex.: Serra Fina, Itatiaia, MG" autocomplete="off" required minlength="2" />
+        <ul id="autocomplete" class="autocomplete" role="listbox" hidden></ul>
+      </div>
+      <button class="button button--primary" type="submit" data-analytics="cta" data-category="search">Buscar</button>
+    </form>
+  </section>
+
+  <section class="section" aria-labelledby="trail-highlights">
+    <div class="section__header">
+      <div>
+        <h2 id="trail-highlights" class="section__title">Trilhas em destaque</h2>
+        <p class="section__description">Confira as 10 trilhas mais buscadas pelos aventureiros nesta semana.</p>
+      </div>
+      <a class="button button--ghost" href="/trilhas.html">Ver todas</a>
+    </div>
+    <div class="cards" id="trailHighlights" data-state="loading" aria-live="polite" aria-busy="true"></div>
+  </section>
+
+  <section class="section" aria-labelledby="guides">
+    <div class="section__header">
+      <div>
+        <h2 id="guides" class="section__title">Guias certificados (CADASTUR)</h2>
+        <p class="section__description">Todos os guias são validados na base CADASTUR diariamente. Faça sua expedição com quem entende.</p>
+      </div>
+      <a class="button button--ghost" href="/guias.html">Ver todos os guias</a>
+    </div>
+    <div class="cards" id="guideHighlights" data-state="loading" aria-live="polite" aria-busy="true"></div>
+  </section>
+
+  <section class="section" aria-labelledby="by-state">
+    <div class="section__header">
+      <h2 id="by-state" class="section__title">Explorar por estado</h2>
+      <p class="section__description">Visualize os estados com mais trilhas cadastradas e planeje sua próxima viagem.</p>
+    </div>
+    <div class="estados-grid" id="estadosGrid" data-state="loading" aria-live="polite" aria-busy="true"></div>
+  </section>
+
+  <section class="section" aria-labelledby="blog">
+    <div class="section__header">
+      <div>
+        <h2 id="blog" class="section__title">Blog e conteúdo</h2>
+        <p class="section__description">Artigos sobre segurança em trilhas, checklist de equipamentos e relatos de expedições.</p>
+      </div>
+      <a class="button button--ghost" href="/blog.html">Ir para o blog</a>
+    </div>
+    <div class="cards" data-state="ready">
+      <article class="card">
+        <div class="card__body">
+          <h3 class="card__title">Checklist de equipamentos para travessias longas</h3>
+          <p class="card__meta">Por Equipe Trekko</p>
+          <p>Entenda os itens indispensáveis para trilhas acima de 20 km e como otimizar o peso da mochila.</p>
+          <a class="button button--ghost" href="/blog/checklist-equipamentos.html">Ler artigo</a>
+        </div>
+      </article>
+      <article class="card">
+        <div class="card__body">
+          <h3 class="card__title">Como funciona a certificação CADASTUR</h3>
+          <p class="card__meta">Por Ministério do Turismo</p>
+          <p>Saiba como identificar um guia certificado e os benefícios para turistas e para o trade turístico.</p>
+          <a class="button button--ghost" href="/blog/cadastur.html">Ler artigo</a>
+        </div>
+      </article>
+    </div>
+  </section>
+
+  <section class="section" aria-labelledby="cta-guia">
+    <div class="section__header">
+      <div>
+        <h2 id="cta-guia" class="section__title">É guia CADASTUR? Ative seu perfil</h2>
+        <p class="section__description">Se você já está na base CADASTUR, basta ativar seu perfil Trekko para divulgar expedições e receber reservas.</p>
+      </div>
+      <a class="button button--primary" href="/login.html?ativar=1" data-analytics="cta" data-category="activate-guide">Ativar guia</a>
+    </div>
+  </section>
+</main>
+<footer class="site-footer">
+  <nav aria-label="Rodapé">
+    <a href="/sobre.html">Sobre</a>
+    <a href="/contato.html">Contato</a>
+    <a href="/politica.html">Política e Termos</a>
+    <a href="/sitemap.xml">Sitemap</a>
+  </nav>
+  <small>© <span id="currentYear">2024</span> Trekko • Todos os direitos reservados</small>
+</footer>
+<script>document.getElementById('currentYear').textContent=new Date().getFullYear();</script>
+<script src="/assets/js/main.js" defer></script>
+</body>
+</html>

--- a/login.html
+++ b/login.html
@@ -1,0 +1,83 @@
+<!doctype html>
+<html lang="pt-BR">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>Entrar na Trekko</title>
+  <meta name="description" content="Acesse sua conta Trekko para acompanhar trilhas, expedições e ativar seu perfil de guia." />
+  <link rel="canonical" href="https://www.trekko.com.br/login.html" />
+  <link rel="preload" href="/assets/css/main.css" as="style" />
+  <link rel="stylesheet" href="/assets/css/main.css" />
+</head>
+<body>
+<a class="skip-link" href="#principal">Pular para o conteúdo</a>
+<header class="site-header">
+  <nav class="nav" aria-label="Principal">
+    <a class="nav__logo" href="/">Trekko</a>
+    <button class="nav__toggle" type="button" aria-expanded="false" aria-controls="menu">Menu</button>
+    <ul id="menu" class="nav__menu" data-state="closed">
+      <li><a href="/trilhas.html">Trilhas</a></li>
+      <li><a href="/guias.html">Guias CADASTUR</a></li>
+      <li><a href="/expedicoes.html">Expedições</a></li>
+      <li><a href="/signup.html" class="button button--ghost">Criar conta</a></li>
+    </ul>
+  </nav>
+</header>
+<main id="principal" class="section">
+  <header class="section__header">
+    <div>
+      <h1 class="section__title">Entrar</h1>
+      <p class="section__description">Use seu e-mail e senha para acessar a Trekko. Se você é guia CADASTUR, ative sua conta após o login.</p>
+    </div>
+  </header>
+
+  <form class="form" id="loginForm" aria-label="Formulário de login" data-analytics="filter" data-category="login">
+    <div class="form__group">
+      <label for="email">E-mail</label>
+      <input id="email" name="email" type="email" required autocomplete="email" />
+    </div>
+    <div class="form__group">
+      <label for="senha">Senha</label>
+      <input id="senha" name="senha" type="password" required autocomplete="current-password" />
+    </div>
+    <div class="form__actions">
+      <button class="button button--primary" type="submit">Entrar</button>
+      <a class="link" href="/signup.html">Criar conta</a>
+    </div>
+  </form>
+
+  <section class="section" aria-labelledby="ativar-guia">
+    <h2 id="ativar-guia" class="section__title">Ativar perfil de guia CADASTUR</h2>
+    <p>Após fazer login, valide sua titularidade na base CADASTUR para publicar expedições.</p>
+    <form class="form" id="activationForm" aria-label="Formulário de ativação de guia">
+      <div class="form__group">
+        <label for="cadasturNome">Nome completo (como no CADASTUR)</label>
+        <input id="cadasturNome" name="nome" type="text" required />
+      </div>
+      <div class="form__group">
+        <label for="cadasturNumero">Número CADASTUR</label>
+        <input id="cadasturNumero" name="cadastur" type="text" required />
+      </div>
+      <div class="form__group">
+        <label for="cadasturContato">Contato cadastrado (e-mail ou telefone)</label>
+        <input id="cadasturContato" name="contato" type="text" required />
+      </div>
+      <div class="form__group">
+        <label for="token">Código de ativação (opcional)</label>
+        <input id="token" name="token" type="text" />
+      </div>
+      <button class="button button--primary" type="submit" data-analytics="cta" data-category="guide_activation">Ativar guia</button>
+    </form>
+  </section>
+</main>
+<footer class="site-footer">
+  <nav aria-label="Rodapé">
+    <a href="/sobre.html">Sobre</a>
+    <a href="/contato.html">Contato</a>
+    <a href="/politica.html">Política e Termos</a>
+  </nav>
+  <small>© Trekko</small>
+</footer>
+<script src="/assets/js/main.js" defer></script>
+</body>
+</html>

--- a/politica.html
+++ b/politica.html
@@ -1,0 +1,68 @@
+<!doctype html>
+<html lang="pt-BR">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>Política de Privacidade e Termos — Trekko</title>
+  <meta name="description" content="Conheça nossas políticas de privacidade, termos de uso e práticas de segurança." />
+  <link rel="canonical" href="https://www.trekko.com.br/politica.html" />
+  <link rel="preload" href="/assets/css/main.css" as="style" />
+  <link rel="stylesheet" href="/assets/css/main.css" />
+</head>
+<body>
+<a class="skip-link" href="#conteudo">Pular para o conteúdo</a>
+<header class="site-header">
+  <nav class="nav" aria-label="Principal">
+    <a class="nav__logo" href="/">Trekko</a>
+    <button class="nav__toggle" type="button" aria-expanded="false" aria-controls="menu">Menu</button>
+    <ul id="menu" class="nav__menu" data-state="closed">
+      <li><a href="/trilhas.html">Trilhas</a></li>
+      <li><a href="/guias.html">Guias CADASTUR</a></li>
+      <li><a href="/expedicoes.html">Expedições</a></li>
+      <li><a href="/login.html" class="button button--ghost">Entrar</a></li>
+    </ul>
+  </nav>
+</header>
+<main id="conteudo" class="section">
+  <header class="section__header">
+    <div>
+      <h1 class="section__title">Política de Privacidade e Termos</h1>
+      <p class="section__description">Entenda como tratamos seus dados e quais são as responsabilidades de uso da plataforma.</p>
+    </div>
+  </header>
+
+  <section class="section" aria-labelledby="dados">
+    <h2 id="dados" class="section__title">Coleta e uso de dados</h2>
+    <p>Coletamos apenas informações necessárias para oferecer os serviços, como nome, e-mail e dados de expedições. Não comercializamos seus dados.</p>
+  </section>
+
+  <section class="section" aria-labelledby="consentimento">
+    <h2 id="consentimento" class="section__title">Consentimento e controle</h2>
+    <p>Você pode gerenciar consentimentos de cookies via banner e solicitar a exclusão da conta a qualquer momento.</p>
+  </section>
+
+  <section class="section" aria-labelledby="seguranca">
+    <h2 id="seguranca" class="section__title">Segurança</h2>
+    <ul class="list">
+      <li>HSTS habilitado e criptografia TLS obrigatória.</li>
+      <li>CSP restritiva e Subresource Integrity (SRI) em assets críticos.</li>
+      <li>Cookies de sessão marcados como Secure e SameSite=Lax.</li>
+    </ul>
+  </section>
+
+  <section class="section" aria-labelledby="responsabilidades">
+    <h2 id="responsabilidades" class="section__title">Responsabilidades do usuário</h2>
+    <p>Usuários devem fornecer informações verídicas, respeitar guias e parques e seguir orientações de segurança.</p>
+  </section>
+</main>
+<footer class="site-footer">
+  <nav aria-label="Rodapé">
+    <a href="/sobre.html">Sobre</a>
+    <a href="/contato.html">Contato</a>
+    <a href="/politica.html" aria-current="page">Política e Termos</a>
+  </nav>
+  <small>© Trekko</small>
+</footer>
+<script src="/assets/js/main.js" defer></script>
+</body>
+</html>

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Allow: /
+Sitemap: https://www.trekko.com.br/sitemap.xml

--- a/signup.html
+++ b/signup.html
@@ -1,0 +1,78 @@
+<!doctype html>
+<html lang="pt-BR">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>Criar conta Trekko</title>
+  <meta name="description" content="Cadastre-se na Trekko para salvar trilhas, comentar e ativar seu perfil de guia CADASTUR." />
+  <link rel="canonical" href="https://www.trekko.com.br/signup.html" />
+  <link rel="preload" href="/assets/css/main.css" as="style" />
+  <link rel="stylesheet" href="/assets/css/main.css" />
+</head>
+<body>
+<a class="skip-link" href="#principal">Pular para o conteúdo</a>
+<header class="site-header">
+  <nav class="nav" aria-label="Principal">
+    <a class="nav__logo" href="/">Trekko</a>
+    <button class="nav__toggle" type="button" aria-expanded="false" aria-controls="menu">Menu</button>
+    <ul id="menu" class="nav__menu" data-state="closed">
+      <li><a href="/trilhas.html">Trilhas</a></li>
+      <li><a href="/guias.html">Guias CADASTUR</a></li>
+      <li><a href="/expedicoes.html">Expedições</a></li>
+      <li><a href="/login.html" class="button button--ghost">Entrar</a></li>
+    </ul>
+  </nav>
+</header>
+<main id="principal" class="section">
+  <header class="section__header">
+    <div>
+      <h1 class="section__title">Criar conta</h1>
+      <p class="section__description">Em poucos passos você poderá seguir trilhas, comentar expedições e ativar seu perfil de guia.</p>
+    </div>
+  </header>
+
+  <form class="form" id="signupForm" aria-label="Formulário de cadastro" data-analytics="filter" data-category="signup">
+    <div class="form__group">
+      <label for="nome">Nome completo</label>
+      <input id="nome" name="nome" type="text" required autocomplete="name" />
+    </div>
+    <div class="form__group">
+      <label for="email">E-mail</label>
+      <input id="email" name="email" type="email" required autocomplete="email" />
+    </div>
+    <div class="form__group">
+      <label for="senha">Senha</label>
+      <input id="senha" name="senha" type="password" required minlength="8" autocomplete="new-password" />
+    </div>
+    <div class="form__group">
+      <label for="confirmacao">Confirmar senha</label>
+      <input id="confirmacao" name="confirmacao" type="password" required minlength="8" autocomplete="new-password" />
+    </div>
+    <label class="form__group"><input type="checkbox" name="aceite" value="true" required /> Concordo com os Termos e Política de Privacidade</label>
+    <div class="form__actions">
+      <button class="button button--primary" type="submit">Criar conta</button>
+      <a class="link" href="/login.html">Já tenho conta</a>
+    </div>
+  </form>
+</main>
+<footer class="site-footer">
+  <nav aria-label="Rodapé">
+    <a href="/sobre.html">Sobre</a>
+    <a href="/contato.html">Contato</a>
+    <a href="/politica.html">Política e Termos</a>
+  </nav>
+  <small>© Trekko</small>
+</footer>
+<script>
+  document.getElementById('signupForm').addEventListener('submit', function(e){
+    const senha=document.getElementById('senha').value;
+    const confirmacao=document.getElementById('confirmacao').value;
+    if(senha!==confirmacao){
+      e.preventDefault();
+      alert('As senhas não conferem.');
+    }
+  });
+</script>
+<script src="/assets/js/main.js" defer></script>
+</body>
+</html>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc>https://www.trekko.com.br/</loc></url>
+  <url><loc>https://www.trekko.com.br/trilhas.html</loc></url>
+  <url><loc>https://www.trekko.com.br/trilha.html</loc></url>
+  <url><loc>https://www.trekko.com.br/guias.html</loc></url>
+  <url><loc>https://www.trekko.com.br/guia.html</loc></url>
+  <url><loc>https://www.trekko.com.br/expedicoes.html</loc></url>
+  <url><loc>https://www.trekko.com.br/criar-expedicao.html</loc></url>
+  <url><loc>https://www.trekko.com.br/login.html</loc></url>
+  <url><loc>https://www.trekko.com.br/signup.html</loc></url>
+  <url><loc>https://www.trekko.com.br/sobre.html</loc></url>
+  <url><loc>https://www.trekko.com.br/contato.html</loc></url>
+  <url><loc>https://www.trekko.com.br/politica.html</loc></url>
+  <url><loc>https://www.trekko.com.br/blog.html</loc></url>
+  <url><loc>https://www.trekko.com.br/blog/checklist-equipamentos.html</loc></url>
+  <url><loc>https://www.trekko.com.br/blog/cadastur.html</loc></url>
+</urlset>

--- a/sobre.html
+++ b/sobre.html
@@ -1,0 +1,63 @@
+<!doctype html>
+<html lang="pt-BR">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>Sobre a Trekko</title>
+  <meta name="description" content="Conheça a história da Trekko, nossa missão e compromissos com trilheiros e guias certificados." />
+  <link rel="canonical" href="https://www.trekko.com.br/sobre.html" />
+  <link rel="preload" href="/assets/css/main.css" as="style" />
+  <link rel="stylesheet" href="/assets/css/main.css" />
+</head>
+<body>
+<a class="skip-link" href="#conteudo">Pular para o conteúdo</a>
+<header class="site-header">
+  <nav class="nav" aria-label="Principal">
+    <a class="nav__logo" href="/">Trekko</a>
+    <button class="nav__toggle" type="button" aria-expanded="false" aria-controls="menu">Menu</button>
+    <ul id="menu" class="nav__menu" data-state="closed">
+      <li><a href="/trilhas.html">Trilhas</a></li>
+      <li><a href="/guias.html">Guias CADASTUR</a></li>
+      <li><a href="/expedicoes.html">Expedições</a></li>
+      <li><a href="/login.html" class="button button--ghost">Entrar</a></li>
+    </ul>
+  </nav>
+</header>
+<main id="conteudo" class="section">
+  <header class="section__header">
+    <div>
+      <h1 class="section__title">Sobre a Trekko</h1>
+      <p class="section__description">Conectamos trilheiros, unidades de conservação e guias certificados para promover turismo responsável no Brasil.</p>
+    </div>
+  </header>
+
+  <section class="section" aria-labelledby="missao">
+    <h2 id="missao" class="section__title">Missão</h2>
+    <p>Facilitar o acesso a informações confiáveis sobre trilhas brasileiras, promovendo experiências seguras, inclusivas e sustentáveis.</p>
+  </section>
+
+  <section class="section" aria-labelledby="valores">
+    <h2 id="valores" class="section__title">Valores</h2>
+    <ul class="list">
+      <li>Transparência na curadoria de dados de trilhas e guias.</li>
+      <li>Compromisso com a conservação ambiental e o turismo de base comunitária.</li>
+      <li>Incentivo à formalização de guias e operadores.</li>
+    </ul>
+  </section>
+
+  <section class="section" aria-labelledby="parcerias">
+    <h2 id="parcerias" class="section__title">Parcerias</h2>
+    <p>Trabalhamos com órgãos oficiais como ICMBio, secretarias estaduais de turismo e associações de montanhismo para manter a base atualizada.</p>
+  </section>
+</main>
+<footer class="site-footer">
+  <nav aria-label="Rodapé">
+    <a href="/sobre.html" aria-current="page">Sobre</a>
+    <a href="/contato.html">Contato</a>
+    <a href="/politica.html">Política e Termos</a>
+  </nav>
+  <small>© Trekko</small>
+</footer>
+<script src="/assets/js/main.js" defer></script>
+</body>
+</html>

--- a/trilha.html
+++ b/trilha.html
@@ -1,0 +1,119 @@
+<!doctype html>
+<html lang="pt-BR">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>Detalhe da trilha — Trekko</title>
+  <meta name="description" content="Informações detalhadas sobre trilhas oficiais: distância, nível, infraestrutura, custos e expedições futuras." />
+  <link rel="canonical" href="https://www.trekko.com.br/trilha.html" />
+  <link rel="preload" href="/assets/css/main.css" as="style" />
+  <link rel="stylesheet" href="/assets/css/main.css" />
+  <meta property="og:title" content="Detalhe da trilha — Trekko" />
+  <meta property="og:type" content="article" />
+  <meta property="og:description" content="Veja dados completos da trilha, logística, comentários e expedições." />
+  <meta property="og:image" content="https://cdn.trekko.com/og-trilha.jpg" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <script type="application/ld+json" id="trailSchema">{"@context":"https://schema.org","@type":"TouristTrip"}</script>
+</head>
+<body>
+<a class="skip-link" href="#conteudo">Pular para o conteúdo</a>
+<header class="site-header">
+  <nav class="nav" aria-label="Principal">
+    <a class="nav__logo" href="/">Trekko</a>
+    <button class="nav__toggle" type="button" aria-expanded="false" aria-controls="menu">Menu</button>
+    <ul id="menu" class="nav__menu" data-state="closed">
+      <li><a href="/trilhas.html">Trilhas</a></li>
+      <li><a href="/guias.html">Guias CADASTUR</a></li>
+      <li><a href="/expedicoes.html">Expedições</a></li>
+      <li><a href="/login.html" class="button button--primary">Entrar</a></li>
+    </ul>
+  </nav>
+</header>
+<main id="conteudo" class="section" data-trail-details>
+  <header class="section__header">
+    <div>
+      <h1 class="section__title" data-trail-name>Trilha</h1>
+      <p class="section__description" data-trail-summary>Carregando informações da trilha...</p>
+      <p class="badge" data-trail-meta></p>
+      <p class="muted" data-trail-location></p>
+    </div>
+    <a class="button button--primary" href="#trailExpeditions" data-analytics="cta" data-category="trail">Agendar expedição</a>
+  </header>
+
+  <section class="section" aria-labelledby="sobre-trilha">
+    <h2 id="sobre-trilha" class="section__title">Informações gerais</h2>
+    <div class="grid grid--two">
+      <article class="details-grid__item">
+        <h3>Infraestrutura</h3>
+        <ul class="list" data-trail-infra></ul>
+      </article>
+      <article class="details-grid__item">
+        <h3>Custos</h3>
+        <table class="table table--pricing" data-trail-costs>
+          <tbody></tbody>
+        </table>
+      </article>
+    </div>
+  </section>
+
+  <section class="section" aria-labelledby="logistica">
+    <h2 id="logistica" class="section__title">Logística e acessos</h2>
+    <div class="details-grid" data-trail-logistics data-state="loading"></div>
+  </section>
+
+  <section class="section" aria-labelledby="mapa">
+    <h2 id="mapa" class="section__title">Mapa da trilha</h2>
+    <div class="iframe-wrapper">
+      <iframe data-trail-map title="Mapa da trilha" loading="lazy" allowfullscreen></iframe>
+    </div>
+  </section>
+
+  <section class="section" aria-labelledby="expedicoes">
+    <div class="section__header">
+      <h2 id="expedicoes" class="section__title">Próximas expedições</h2>
+      <a class="button button--ghost" href="/expedicoes.html" data-analytics="cta" data-category="trail">Ver todas as expedições</a>
+    </div>
+    <div id="trailExpeditions" class="grid" data-state="loading" aria-live="polite"></div>
+  </section>
+
+  <section class="section" id="trailComments" aria-labelledby="comentarios">
+    <div class="section__header">
+      <h2 id="comentarios" class="section__title">Comentários da comunidade</h2>
+    </div>
+    <p class="status-indicator" data-state="loading">Carregando comentários</p>
+    <div data-comments-list class="grid" aria-live="polite"></div>
+    <form class="form comment-form" id="commentForm" aria-label="Enviar comentário" method="post">
+      <div class="form__group">
+        <label for="mensagem">Compartilhe sua experiência</label>
+        <textarea id="mensagem" name="mensagem" rows="4" required minlength="10" placeholder="Conte como foi sua expedição"></textarea>
+      </div>
+      <div class="form__actions">
+        <button class="button button--primary" type="submit">Publicar comentário</button>
+        <p class="muted">Necessário estar autenticado.</p>
+      </div>
+    </form>
+  </section>
+
+  <div data-trail-status class="status-indicator" data-state="loading">Carregando detalhes</div>
+</main>
+<footer class="site-footer">
+  <nav aria-label="Rodapé">
+    <a href="/sobre.html">Sobre</a>
+    <a href="/contato.html">Contato</a>
+    <a href="/politica.html">Política e Termos</a>
+  </nav>
+  <small>© Trekko</small>
+</footer>
+<script>
+  (function(){
+    const params=new URLSearchParams(location.search);
+    const id=params.get('id');
+    if(id){
+      const form=document.getElementById('commentForm');
+      if(form){form.dataset.trailId=id;}
+    }
+  })();
+</script>
+<script src="/assets/js/main.js" defer></script>
+</body>
+</html>

--- a/trilhas.html
+++ b/trilhas.html
@@ -1,0 +1,117 @@
+<!doctype html>
+<html lang="pt-BR">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>Trilhas reais pelo Brasil — Trekko</title>
+  <meta name="description" content="Busque trilhas homologadas por parque, dificuldade, distância, infraestrutura e planeje sua próxima expedição." />
+  <link rel="canonical" href="https://www.trekko.com.br/trilhas.html" />
+  <link rel="preconnect" href="https://cdn.trekko.com" />
+  <link rel="preload" href="/assets/css/main.css" as="style" />
+  <link rel="stylesheet" href="/assets/css/main.css" />
+  <meta property="og:title" content="Trilhas reais pelo Brasil — Trekko" />
+  <meta property="og:description" content="Filtre trilhas por distância, dificuldade e infraestrutura e encontre informações confiáveis." />
+  <meta property="og:type" content="website" />
+  <meta property="og:url" content="https://www.trekko.com.br/trilhas.html" />
+  <meta property="og:image" content="https://cdn.trekko.com/og-trilhas.jpg" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <style>
+    body{margin:0;font-family:"Outfit","Sora",sans-serif;color:#333;background:#f6f6f4}
+  </style>
+</head>
+<body>
+<a class="skip-link" href="#content">Pular para o conteúdo</a>
+<header class="site-header">
+  <nav class="nav" aria-label="Principal">
+    <a class="nav__logo" href="/">Trekko</a>
+    <button class="nav__toggle" type="button" aria-expanded="false" aria-controls="menu">Menu</button>
+    <ul id="menu" class="nav__menu" data-state="closed">
+      <li><a href="/trilhas.html" aria-current="page">Trilhas</a></li>
+      <li><a href="/guias.html">Guias CADASTUR</a></li>
+      <li><a href="/expedicoes.html">Expedições</a></li>
+      <li><a href="/login.html" class="button button--primary">Entrar</a></li>
+    </ul>
+  </nav>
+</header>
+<main id="content" class="section">
+  <header class="section__header">
+    <div>
+      <h1 class="section__title">Trilhas do Brasil</h1>
+      <p class="section__description">Dados oficiais de parques nacionais, estaduais e municipais com infraestrutura verificada.</p>
+    </div>
+    <p id="trailCounter" class="badge" aria-live="polite">Carregando trilhas...</p>
+  </header>
+
+  <form class="filters" id="trailFilters" aria-label="Filtros de trilhas" method="get" data-analytics="filter" data-category="trail_filters">
+    <input type="search" name="nome" placeholder="Nome da trilha" aria-label="Nome da trilha" />
+    <input type="search" name="parque" placeholder="Parque ou região" aria-label="Parque ou região" />
+    <input type="search" name="cidade" placeholder="Cidade" aria-label="Cidade" />
+    <select name="estado" aria-label="Estado (UF)">
+      <option value="">UF</option>
+      <option value="AC">AC</option>
+      <option value="AL">AL</option>
+      <option value="AM">AM</option>
+      <option value="AP">AP</option>
+      <option value="BA">BA</option>
+      <option value="CE">CE</option>
+      <option value="DF">DF</option>
+      <option value="ES">ES</option>
+      <option value="GO">GO</option>
+      <option value="MA">MA</option>
+      <option value="MG">MG</option>
+      <option value="MS">MS</option>
+      <option value="MT">MT</option>
+      <option value="PA">PA</option>
+      <option value="PB">PB</option>
+      <option value="PE">PE</option>
+      <option value="PI">PI</option>
+      <option value="PR">PR</option>
+      <option value="RJ">RJ</option>
+      <option value="RN">RN</option>
+      <option value="RO">RO</option>
+      <option value="RR">RR</option>
+      <option value="RS">RS</option>
+      <option value="SC">SC</option>
+      <option value="SE">SE</option>
+      <option value="SP">SP</option>
+      <option value="TO">TO</option>
+    </select>
+    <select name="nivel" aria-label="Nível da trilha">
+      <option value="">Todos os níveis</option>
+      <option value="Fácil">Fácil</option>
+      <option value="Médio">Médio</option>
+      <option value="Difícil">Difícil</option>
+    </select>
+    <input type="number" name="distanciaMax" placeholder="Distância máxima (km)" aria-label="Distância máxima" min="0" step="0.5" />
+    <input type="number" name="ganhoMax" placeholder="Ganho de altitude máximo (m)" aria-label="Ganho de altitude máximo" min="0" step="10" />
+    <fieldset>
+      <legend>Estrutura</legend>
+      <label><input type="checkbox" name="agua" value="true" /> Água</label>
+      <label><input type="checkbox" name="camping" value="true" /> Camping</label>
+      <label><input type="checkbox" name="estacionamento" value="true" /> Estacionamento</label>
+    </fieldset>
+    <select name="ordenar" aria-label="Ordenação">
+      <option value="relevance">Relevância</option>
+      <option value="likes">Mais curtidas</option>
+      <option value="distance">Distância</option>
+      <option value="gain">Ganho alt.</option>
+      <option value="duration">Duração</option>
+    </select>
+    <input type="hidden" name="page" value="1" />
+    <button class="button button--primary" type="submit" data-analytics="cta" data-category="trail_filters">Aplicar filtros</button>
+  </form>
+
+  <div class="cards" id="trailsList" data-state="loading" aria-live="polite" aria-busy="true"></div>
+  <nav class="pagination" id="trailPagination" role="navigation" aria-label="Paginação de trilhas"></nav>
+</main>
+<footer class="site-footer">
+  <nav aria-label="Rodapé">
+    <a href="/sobre.html">Sobre</a>
+    <a href="/contato.html">Contato</a>
+    <a href="/politica.html">Política e Termos</a>
+  </nav>
+  <small>© Trekko</small>
+</footer>
+<script src="/assets/js/main.js" defer></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- implement responsive, accessible multi-page Trekko frontend with navigation, filters, and structured data
- add reusable CSS and JavaScript handling autocomplete, pagination, API consumption, and analytics
- provide supporting content pages, admin tools, error pages, and SEO assets like sitemap and robots

## Testing
- no automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e58e413ad48324b8bd65dc5e86f50f