### PR TITLE
Fix navigation paths for GitHub Pages deployment

### DIFF
--- a/404.html
+++ b/404.html
@@ -2,22 +2,23 @@
 <html lang="pt-BR">
 <head>
   <meta charset="utf-8" />
+  <base href="/Trekko/" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>Página não encontrada — Trekko</title>
   <meta name="description" content="A página solicitada não foi encontrada. Continue explorando trilhas e expedições." />
-  <link rel="preload" href="/assets/css/main.css" as="style" />
-  <link rel="stylesheet" href="/assets/css/main.css" />
+  <link rel="preload" href="assets/css/main.css" as="style" />
+  <link rel="stylesheet" href="assets/css/main.css" />
 </head>
 <body>
 <a class="skip-link" href="#conteudo">Pular para o conteúdo</a>
 <header class="site-header">
   <nav class="nav" aria-label="Principal">
-    <a class="nav__logo" href="/">Trekko</a>
+    <a class="nav__logo" href="./">Trekko</a>
     <button class="nav__toggle" type="button" aria-expanded="false" aria-controls="menu">Menu</button>
     <ul id="menu" class="nav__menu" data-state="closed">
-      <li><a href="/trilhas.html">Trilhas</a></li>
-      <li><a href="/guias.html">Guias CADASTUR</a></li>
-      <li><a href="/expedicoes.html">Expedições</a></li>
+      <li><a href="trilhas.html">Trilhas</a></li>
+      <li><a href="guias.html">Guias CADASTUR</a></li>
+      <li><a href="expedicoes.html">Expedições</a></li>
     </ul>
   </nav>
 </header>
@@ -25,18 +26,18 @@
   <h1 class="section__title">Erro 404</h1>
   <p class="section__description">A trilha que você tentou acessar não existe. Explore as opções abaixo.</p>
   <div class="card__actions" style="justify-content:center;">
-    <a class="button button--primary" href="/trilhas.html">Ver trilhas</a>
-    <a class="button button--ghost" href="/">Ir para a Home</a>
+    <a class="button button--primary" href="trilhas.html">Ver trilhas</a>
+    <a class="button button--ghost" href="./">Ir para a Home</a>
   </div>
 </main>
 <footer class="site-footer">
   <nav aria-label="Rodapé">
-    <a href="/sobre.html">Sobre</a>
-    <a href="/contato.html">Contato</a>
-    <a href="/politica.html">Política e Termos</a>
+    <a href="sobre.html">Sobre</a>
+    <a href="contato.html">Contato</a>
+    <a href="politica.html">Política e Termos</a>
   </nav>
   <small>© Trekko</small>
 </footer>
-<script src="/assets/js/main.js" defer></script>
+<script src="assets/js/main.js" defer></script>
 </body>
 </html>

--- a/500.html
+++ b/500.html
@@ -2,22 +2,23 @@
 <html lang="pt-BR">
 <head>
   <meta charset="utf-8" />
+  <base href="/Trekko/" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>Erro interno — Trekko</title>
   <meta name="description" content="Ocorreu um erro interno. Nossa equipe já foi notificada." />
-  <link rel="preload" href="/assets/css/main.css" as="style" />
-  <link rel="stylesheet" href="/assets/css/main.css" />
+  <link rel="preload" href="assets/css/main.css" as="style" />
+  <link rel="stylesheet" href="assets/css/main.css" />
 </head>
 <body>
 <a class="skip-link" href="#conteudo">Pular para o conteúdo</a>
 <header class="site-header">
   <nav class="nav" aria-label="Principal">
-    <a class="nav__logo" href="/">Trekko</a>
+    <a class="nav__logo" href="./">Trekko</a>
     <button class="nav__toggle" type="button" aria-expanded="false" aria-controls="menu">Menu</button>
     <ul id="menu" class="nav__menu" data-state="closed">
-      <li><a href="/trilhas.html">Trilhas</a></li>
-      <li><a href="/guias.html">Guias CADASTUR</a></li>
-      <li><a href="/expedicoes.html">Expedições</a></li>
+      <li><a href="trilhas.html">Trilhas</a></li>
+      <li><a href="guias.html">Guias CADASTUR</a></li>
+      <li><a href="expedicoes.html">Expedições</a></li>
     </ul>
   </nav>
 </header>
@@ -25,18 +26,18 @@
   <h1 class="section__title">Erro 500</h1>
   <p class="section__description">Algo inesperado aconteceu. Nossa equipe técnica já foi alertada.</p>
   <div class="card__actions" style="justify-content:center;">
-    <a class="button button--primary" href="/">Voltar para a Home</a>
-    <a class="button button--ghost" href="/contato.html">Falar com suporte</a>
+    <a class="button button--primary" href="./">Voltar para a Home</a>
+    <a class="button button--ghost" href="contato.html">Falar com suporte</a>
   </div>
 </main>
 <footer class="site-footer">
   <nav aria-label="Rodapé">
-    <a href="/sobre.html">Sobre</a>
-    <a href="/contato.html">Contato</a>
-    <a href="/politica.html">Política e Termos</a>
+    <a href="sobre.html">Sobre</a>
+    <a href="contato.html">Contato</a>
+    <a href="politica.html">Política e Termos</a>
   </nav>
   <small>© Trekko</small>
 </footer>
-<script src="/assets/js/main.js" defer></script>
+<script src="assets/js/main.js" defer></script>
 </body>
 </html>

--- a/admin.html
+++ b/admin.html
@@ -2,25 +2,26 @@
 <html lang="pt-BR">
 <head>
   <meta charset="utf-8" />
+  <base href="/Trekko/" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>Painel administrativo — Trekko</title>
   <meta name="description" content="Área restrita para gestão da base CADASTUR, trilhas, expedições e usuários." />
   <link rel="canonical" href="https://www.trekko.com.br/admin.html" />
-  <link rel="preload" href="/assets/css/main.css" as="style" />
-  <link rel="stylesheet" href="/assets/css/main.css" />
+  <link rel="preload" href="assets/css/main.css" as="style" />
+  <link rel="stylesheet" href="assets/css/main.css" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; img-src 'self' https://images.unsplash.com https://cdn.trekko.com; connect-src 'self'; script-src 'self'; style-src 'self';" />
 </head>
 <body>
 <a class="skip-link" href="#painel">Pular para o conteúdo</a>
 <header class="site-header">
   <nav class="nav" aria-label="Principal">
-    <a class="nav__logo" href="/">Trekko</a>
+    <a class="nav__logo" href="./">Trekko</a>
     <button class="nav__toggle" type="button" aria-expanded="false" aria-controls="menu">Menu</button>
     <ul id="menu" class="nav__menu" data-state="closed">
-      <li><a href="/trilhas.html">Trilhas</a></li>
-      <li><a href="/guias.html">Guias CADASTUR</a></li>
-      <li><a href="/expedicoes.html">Expedições</a></li>
-      <li><a href="/login.html" class="button button--ghost">Sair</a></li>
+      <li><a href="trilhas.html">Trilhas</a></li>
+      <li><a href="guias.html">Guias CADASTUR</a></li>
+      <li><a href="expedicoes.html">Expedições</a></li>
+      <li><a href="login.html" class="button button--ghost">Sair</a></li>
     </ul>
   </nav>
 </header>
@@ -79,12 +80,12 @@
 </main>
 <footer class="site-footer">
   <nav aria-label="Rodapé">
-    <a href="/sobre.html">Sobre</a>
-    <a href="/contato.html">Contato</a>
-    <a href="/politica.html">Política e Termos</a>
+    <a href="sobre.html">Sobre</a>
+    <a href="contato.html">Contato</a>
+    <a href="politica.html">Política e Termos</a>
   </nav>
   <small>© Trekko</small>
 </footer>
-<script src="/assets/js/main.js" defer></script>
+<script src="assets/js/main.js" defer></script>
 </body>
 </html>

--- a/blog.html
+++ b/blog.html
@@ -2,24 +2,25 @@
 <html lang="pt-BR">
 <head>
   <meta charset="utf-8" />
+  <base href="/Trekko/" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>Blog Trekko</title>
   <meta name="description" content="Conteúdo sobre trilhas, segurança e bastidores do turismo de aventura no Brasil." />
   <link rel="canonical" href="https://www.trekko.com.br/blog.html" />
-  <link rel="preload" href="/assets/css/main.css" as="style" />
-  <link rel="stylesheet" href="/assets/css/main.css" />
+  <link rel="preload" href="assets/css/main.css" as="style" />
+  <link rel="stylesheet" href="assets/css/main.css" />
 </head>
 <body>
 <a class="skip-link" href="#conteudo">Pular para o conteúdo</a>
 <header class="site-header">
   <nav class="nav" aria-label="Principal">
-    <a class="nav__logo" href="/">Trekko</a>
+    <a class="nav__logo" href="./">Trekko</a>
     <button class="nav__toggle" type="button" aria-expanded="false" aria-controls="menu">Menu</button>
     <ul id="menu" class="nav__menu" data-state="closed">
-      <li><a href="/trilhas.html">Trilhas</a></li>
-      <li><a href="/guias.html">Guias CADASTUR</a></li>
-      <li><a href="/expedicoes.html">Expedições</a></li>
-      <li><a href="/login.html" class="button button--ghost">Entrar</a></li>
+      <li><a href="trilhas.html">Trilhas</a></li>
+      <li><a href="guias.html">Guias CADASTUR</a></li>
+      <li><a href="expedicoes.html">Expedições</a></li>
+      <li><a href="login.html" class="button button--ghost">Entrar</a></li>
     </ul>
   </nav>
 </header>
@@ -34,14 +35,14 @@
   <div class="cards" data-state="ready">
     <article class="card">
       <div class="card__body">
-        <h2 class="card__title"><a href="/blog/checklist-equipamentos.html">Checklist de equipamentos para travessias</a></h2>
+        <h2 class="card__title"><a href="blog/checklist-equipamentos.html">Checklist de equipamentos para travessias</a></h2>
         <p class="card__meta">Atualizado em 02/01/2024</p>
         <p>Organize a mochila ideal para travessias com grande desnível e clima variável.</p>
       </div>
     </article>
     <article class="card">
       <div class="card__body">
-        <h2 class="card__title"><a href="/blog/cadastur.html">Por que contratar guias CADASTUR</a></h2>
+        <h2 class="card__title"><a href="blog/cadastur.html">Por que contratar guias CADASTUR</a></h2>
         <p class="card__meta">Atualizado em 15/12/2023</p>
         <p>Entenda os critérios de certificação e como validar a credencial de um guia.</p>
       </div>
@@ -50,12 +51,12 @@
 </main>
 <footer class="site-footer">
   <nav aria-label="Rodapé">
-    <a href="/sobre.html">Sobre</a>
-    <a href="/contato.html">Contato</a>
-    <a href="/politica.html">Política e Termos</a>
+    <a href="sobre.html">Sobre</a>
+    <a href="contato.html">Contato</a>
+    <a href="politica.html">Política e Termos</a>
   </nav>
   <small>© Trekko</small>
 </footer>
-<script src="/assets/js/main.js" defer></script>
+<script src="assets/js/main.js" defer></script>
 </body>
 </html>

--- a/blog/cadastur.html
+++ b/blog/cadastur.html
@@ -2,24 +2,25 @@
 <html lang="pt-BR">
 <head>
   <meta charset="utf-8" />
+  <base href="/Trekko/" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>Como validar um guia CADASTUR — Trekko</title>
   <meta name="description" content="Confira os passos para verificar se um guia é certificado pelo Ministério do Turismo." />
   <link rel="canonical" href="https://www.trekko.com.br/blog/cadastur.html" />
-  <link rel="preload" href="/assets/css/main.css" as="style" />
-  <link rel="stylesheet" href="/assets/css/main.css" />
+  <link rel="preload" href="assets/css/main.css" as="style" />
+  <link rel="stylesheet" href="assets/css/main.css" />
 </head>
 <body>
 <a class="skip-link" href="#conteudo">Pular para o conteúdo</a>
 <header class="site-header">
   <nav class="nav" aria-label="Principal">
-    <a class="nav__logo" href="/">Trekko</a>
+    <a class="nav__logo" href="./">Trekko</a>
     <button class="nav__toggle" type="button" aria-expanded="false" aria-controls="menu">Menu</button>
     <ul id="menu" class="nav__menu" data-state="closed">
-      <li><a href="/trilhas.html">Trilhas</a></li>
-      <li><a href="/guias.html">Guias CADASTUR</a></li>
-      <li><a href="/expedicoes.html">Expedições</a></li>
-      <li><a href="/login.html" class="button button--ghost">Entrar</a></li>
+      <li><a href="trilhas.html">Trilhas</a></li>
+      <li><a href="guias.html">Guias CADASTUR</a></li>
+      <li><a href="expedicoes.html">Expedições</a></li>
+      <li><a href="login.html" class="button button--ghost">Entrar</a></li>
     </ul>
   </nav>
 </header>
@@ -45,12 +46,12 @@
 </main>
 <footer class="site-footer">
   <nav aria-label="Rodapé">
-    <a href="/sobre.html">Sobre</a>
-    <a href="/contato.html">Contato</a>
-    <a href="/politica.html">Política e Termos</a>
+    <a href="sobre.html">Sobre</a>
+    <a href="contato.html">Contato</a>
+    <a href="politica.html">Política e Termos</a>
   </nav>
   <small>© Trekko</small>
 </footer>
-<script src="/assets/js/main.js" defer></script>
+<script src="assets/js/main.js" defer></script>
 </body>
 </html>

--- a/blog/checklist-equipamentos.html
+++ b/blog/checklist-equipamentos.html
@@ -2,25 +2,26 @@
 <html lang="pt-BR">
 <head>
   <meta charset="utf-8" />
+  <base href="/Trekko/" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>Checklist de equipamentos para travessias — Trekko</title>
   <meta name="description" content="Saiba como montar uma mochila equilibrada para travessias de montanha com segurança." />
   <link rel="canonical" href="https://www.trekko.com.br/blog/checklist-equipamentos.html" />
-  <link rel="preload" href="/assets/css/main.css" as="style" />
-  <link rel="stylesheet" href="/assets/css/main.css" />
+  <link rel="preload" href="assets/css/main.css" as="style" />
+  <link rel="stylesheet" href="assets/css/main.css" />
   <article itemscope itemtype="https://schema.org/BlogPosting"></article>
 </head>
 <body>
 <a class="skip-link" href="#conteudo">Pular para o conteúdo</a>
 <header class="site-header">
   <nav class="nav" aria-label="Principal">
-    <a class="nav__logo" href="/">Trekko</a>
+    <a class="nav__logo" href="./">Trekko</a>
     <button class="nav__toggle" type="button" aria-expanded="false" aria-controls="menu">Menu</button>
     <ul id="menu" class="nav__menu" data-state="closed">
-      <li><a href="/trilhas.html">Trilhas</a></li>
-      <li><a href="/guias.html">Guias CADASTUR</a></li>
-      <li><a href="/expedicoes.html">Expedições</a></li>
-      <li><a href="/login.html" class="button button--ghost">Entrar</a></li>
+      <li><a href="trilhas.html">Trilhas</a></li>
+      <li><a href="guias.html">Guias CADASTUR</a></li>
+      <li><a href="expedicoes.html">Expedições</a></li>
+      <li><a href="login.html" class="button button--ghost">Entrar</a></li>
     </ul>
   </nav>
 </header>
@@ -46,12 +47,12 @@
 </main>
 <footer class="site-footer">
   <nav aria-label="Rodapé">
-    <a href="/sobre.html">Sobre</a>
-    <a href="/contato.html">Contato</a>
-    <a href="/politica.html">Política e Termos</a>
+    <a href="sobre.html">Sobre</a>
+    <a href="contato.html">Contato</a>
+    <a href="politica.html">Política e Termos</a>
   </nav>
   <small>© Trekko</small>
 </footer>
-<script src="/assets/js/main.js" defer></script>
+<script src="assets/js/main.js" defer></script>
 </body>
 </html>

--- a/contato.html
+++ b/contato.html
@@ -2,24 +2,25 @@
 <html lang="pt-BR">
 <head>
   <meta charset="utf-8" />
+  <base href="/Trekko/" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>Contato — Trekko</title>
   <meta name="description" content="Fale com a equipe Trekko para parcerias, suporte ou dúvidas sobre trilhas e expedições." />
   <link rel="canonical" href="https://www.trekko.com.br/contato.html" />
-  <link rel="preload" href="/assets/css/main.css" as="style" />
-  <link rel="stylesheet" href="/assets/css/main.css" />
+  <link rel="preload" href="assets/css/main.css" as="style" />
+  <link rel="stylesheet" href="assets/css/main.css" />
 </head>
 <body>
 <a class="skip-link" href="#conteudo">Pular para o conteúdo</a>
 <header class="site-header">
   <nav class="nav" aria-label="Principal">
-    <a class="nav__logo" href="/">Trekko</a>
+    <a class="nav__logo" href="./">Trekko</a>
     <button class="nav__toggle" type="button" aria-expanded="false" aria-controls="menu">Menu</button>
     <ul id="menu" class="nav__menu" data-state="closed">
-      <li><a href="/trilhas.html">Trilhas</a></li>
-      <li><a href="/guias.html">Guias CADASTUR</a></li>
-      <li><a href="/expedicoes.html">Expedições</a></li>
-      <li><a href="/login.html" class="button button--ghost">Entrar</a></li>
+      <li><a href="trilhas.html">Trilhas</a></li>
+      <li><a href="guias.html">Guias CADASTUR</a></li>
+      <li><a href="expedicoes.html">Expedições</a></li>
+      <li><a href="login.html" class="button button--ghost">Entrar</a></li>
     </ul>
   </nav>
 </header>
@@ -74,12 +75,12 @@
 </main>
 <footer class="site-footer">
   <nav aria-label="Rodapé">
-    <a href="/sobre.html">Sobre</a>
-    <a href="/contato.html" aria-current="page">Contato</a>
-    <a href="/politica.html">Política e Termos</a>
+    <a href="sobre.html">Sobre</a>
+    <a href="contato.html" aria-current="page">Contato</a>
+    <a href="politica.html">Política e Termos</a>
   </nav>
   <small>© Trekko</small>
 </footer>
-<script src="/assets/js/main.js" defer></script>
+<script src="assets/js/main.js" defer></script>
 </body>
 </html>

--- a/criar-expedicao.html
+++ b/criar-expedicao.html
@@ -2,12 +2,13 @@
 <html lang="pt-BR">
 <head>
   <meta charset="utf-8" />
+  <base href="/Trekko/" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>Criar expedição — Trekko</title>
   <meta name="description" content="Publique expedições vinculadas a trilhas oficiais e controle vagas, preço e datas." />
   <link rel="canonical" href="https://www.trekko.com.br/criar-expedicao.html" />
-  <link rel="preload" href="/assets/css/main.css" as="style" />
-  <link rel="stylesheet" href="/assets/css/main.css" />
+  <link rel="preload" href="assets/css/main.css" as="style" />
+  <link rel="stylesheet" href="assets/css/main.css" />
   <meta property="og:title" content="Criar expedição — Trekko" />
   <meta property="og:type" content="website" />
   <meta property="og:description" content="Ferramenta exclusiva para guias CADASTUR ativados organizarem suas expedições." />
@@ -16,13 +17,13 @@
 <a class="skip-link" href="#conteudo">Pular para o conteúdo</a>
 <header class="site-header">
   <nav class="nav" aria-label="Principal">
-    <a class="nav__logo" href="/">Trekko</a>
+    <a class="nav__logo" href="./">Trekko</a>
     <button class="nav__toggle" type="button" aria-expanded="false" aria-controls="menu">Menu</button>
     <ul id="menu" class="nav__menu" data-state="closed">
-      <li><a href="/trilhas.html">Trilhas</a></li>
-      <li><a href="/guias.html">Guias CADASTUR</a></li>
-      <li><a href="/expedicoes.html">Expedições</a></li>
-      <li><a href="/login.html" class="button button--primary">Entrar</a></li>
+      <li><a href="trilhas.html">Trilhas</a></li>
+      <li><a href="guias.html">Guias CADASTUR</a></li>
+      <li><a href="expedicoes.html">Expedições</a></li>
+      <li><a href="login.html" class="button button--primary">Entrar</a></li>
     </ul>
   </nav>
 </header>
@@ -87,12 +88,12 @@
 </main>
 <footer class="site-footer">
   <nav aria-label="Rodapé">
-    <a href="/sobre.html">Sobre</a>
-    <a href="/contato.html">Contato</a>
-    <a href="/politica.html">Política e Termos</a>
+    <a href="sobre.html">Sobre</a>
+    <a href="contato.html">Contato</a>
+    <a href="politica.html">Política e Termos</a>
   </nav>
   <small>© Trekko</small>
 </footer>
-<script src="/assets/js/main.js" defer></script>
+<script src="assets/js/main.js" defer></script>
 </body>
 </html>

--- a/expedicoes.html
+++ b/expedicoes.html
@@ -2,12 +2,13 @@
 <html lang="pt-BR">
 <head>
   <meta charset="utf-8" />
+  <base href="/Trekko/" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>Expedições em trilhas brasileiras — Trekko</title>
   <meta name="description" content="Pesquise expedições cadastradas pelos guias CADASTUR com datas e vagas atualizadas." />
   <link rel="canonical" href="https://www.trekko.com.br/expedicoes.html" />
-  <link rel="preload" href="/assets/css/main.css" as="style" />
-  <link rel="stylesheet" href="/assets/css/main.css" />
+  <link rel="preload" href="assets/css/main.css" as="style" />
+  <link rel="stylesheet" href="assets/css/main.css" />
   <meta property="og:title" content="Expedições em trilhas brasileiras — Trekko" />
   <meta property="og:type" content="website" />
   <meta property="og:description" content="Expedições reais cadastradas pelos guias ativos da plataforma." />
@@ -16,13 +17,13 @@
 <a class="skip-link" href="#conteudo">Pular para o conteúdo</a>
 <header class="site-header">
   <nav class="nav" aria-label="Principal">
-    <a class="nav__logo" href="/">Trekko</a>
+    <a class="nav__logo" href="./">Trekko</a>
     <button class="nav__toggle" type="button" aria-expanded="false" aria-controls="menu">Menu</button>
     <ul id="menu" class="nav__menu" data-state="closed">
-      <li><a href="/trilhas.html">Trilhas</a></li>
-      <li><a href="/guias.html">Guias CADASTUR</a></li>
-      <li><a href="/expedicoes.html" aria-current="page">Expedições</a></li>
-      <li><a href="/login.html" class="button button--primary">Entrar</a></li>
+      <li><a href="trilhas.html">Trilhas</a></li>
+      <li><a href="guias.html">Guias CADASTUR</a></li>
+      <li><a href="expedicoes.html" aria-current="page">Expedições</a></li>
+      <li><a href="login.html" class="button button--primary">Entrar</a></li>
     </ul>
   </nav>
 </header>
@@ -32,7 +33,7 @@
       <h1 class="section__title">Expedições disponíveis</h1>
       <p class="section__description">Somente expedições criadas na plataforma pelos guias ativos são exibidas aqui.</p>
     </div>
-    <a class="button button--ghost" href="/criar-expedicao.html">Criar expedição</a>
+    <a class="button button--ghost" href="criar-expedicao.html">Criar expedição</a>
   </header>
 
   <form class="filters" id="expeditionFilters" aria-label="Filtros de expedições" method="get" data-analytics="filter" data-category="expedition_filters">
@@ -50,12 +51,12 @@
 </main>
 <footer class="site-footer">
   <nav aria-label="Rodapé">
-    <a href="/sobre.html">Sobre</a>
-    <a href="/contato.html">Contato</a>
-    <a href="/politica.html">Política e Termos</a>
+    <a href="sobre.html">Sobre</a>
+    <a href="contato.html">Contato</a>
+    <a href="politica.html">Política e Termos</a>
   </nav>
   <small>© Trekko</small>
 </footer>
-<script src="/assets/js/main.js" defer></script>
+<script src="assets/js/main.js" defer></script>
 </body>
 </html>

--- a/guia.html
+++ b/guia.html
@@ -2,12 +2,13 @@
 <html lang="pt-BR">
 <head>
   <meta charset="utf-8" />
+  <base href="/Trekko/" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>Perfil do guia — Trekko</title>
   <meta name="description" content="Veja informações completas do guia CADASTUR, contatos e expedições disponíveis." />
   <link rel="canonical" href="https://www.trekko.com.br/guia.html" />
-  <link rel="preload" href="/assets/css/main.css" as="style" />
-  <link rel="stylesheet" href="/assets/css/main.css" />
+  <link rel="preload" href="assets/css/main.css" as="style" />
+  <link rel="stylesheet" href="assets/css/main.css" />
   <meta property="og:title" content="Perfil do guia — Trekko" />
   <meta property="og:type" content="profile" />
   <meta property="og:description" content="Confirme a certificação CADASTUR e agende expedições diretamente com o guia." />
@@ -18,13 +19,13 @@
 <a class="skip-link" href="#principal">Pular para o conteúdo</a>
 <header class="site-header">
   <nav class="nav" aria-label="Principal">
-    <a class="nav__logo" href="/">Trekko</a>
+    <a class="nav__logo" href="./">Trekko</a>
     <button class="nav__toggle" type="button" aria-expanded="false" aria-controls="menu">Menu</button>
     <ul id="menu" class="nav__menu" data-state="closed">
-      <li><a href="/trilhas.html">Trilhas</a></li>
-      <li><a href="/guias.html">Guias CADASTUR</a></li>
-      <li><a href="/expedicoes.html">Expedições</a></li>
-      <li><a href="/login.html" class="button button--primary">Entrar</a></li>
+      <li><a href="trilhas.html">Trilhas</a></li>
+      <li><a href="guias.html">Guias CADASTUR</a></li>
+      <li><a href="expedicoes.html">Expedições</a></li>
+      <li><a href="login.html" class="button button--primary">Entrar</a></li>
     </ul>
   </nav>
 </header>
@@ -51,7 +52,7 @@
   <section class="section" aria-labelledby="expedicoes-guia">
     <div class="section__header">
       <h2 id="expedicoes-guia" class="section__title">Expedições publicadas</h2>
-      <a class="button button--ghost" href="/criar-expedicao.html" data-analytics="cta" data-category="guide">Criar expedição</a>
+      <a class="button button--ghost" href="criar-expedicao.html" data-analytics="cta" data-category="guide">Criar expedição</a>
     </div>
     <div id="guideExpeditions" class="grid" data-state="loading" aria-live="polite"></div>
   </section>
@@ -60,12 +61,12 @@
 </main>
 <footer class="site-footer">
   <nav aria-label="Rodapé">
-    <a href="/sobre.html">Sobre</a>
-    <a href="/contato.html">Contato</a>
-    <a href="/politica.html">Política e Termos</a>
+    <a href="sobre.html">Sobre</a>
+    <a href="contato.html">Contato</a>
+    <a href="politica.html">Política e Termos</a>
   </nav>
   <small>© Trekko</small>
 </footer>
-<script src="/assets/js/main.js" defer></script>
+<script src="assets/js/main.js" defer></script>
 </body>
 </html>

--- a/guias.html
+++ b/guias.html
@@ -2,12 +2,13 @@
 <html lang="pt-BR">
 <head>
   <meta charset="utf-8" />
+  <base href="/Trekko/" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>Guias CADASTUR certificados — Trekko</title>
   <meta name="description" content="Encontre guias turísticos cadastrados no CADASTUR por UF, cidade ou número de registro e ative o contato direto." />
   <link rel="canonical" href="https://www.trekko.com.br/guias.html" />
-  <link rel="preload" href="/assets/css/main.css" as="style" />
-  <link rel="stylesheet" href="/assets/css/main.css" />
+  <link rel="preload" href="assets/css/main.css" as="style" />
+  <link rel="stylesheet" href="assets/css/main.css" />
   <meta property="og:title" content="Guias CADASTUR certificados — Trekko" />
   <meta property="og:type" content="website" />
   <meta property="og:description" content="Lista oficial integrada à base CADASTUR com filtros por localização." />
@@ -18,13 +19,13 @@
 <a class="skip-link" href="#content">Pular para o conteúdo</a>
 <header class="site-header">
   <nav class="nav" aria-label="Principal">
-    <a class="nav__logo" href="/">Trekko</a>
+    <a class="nav__logo" href="./">Trekko</a>
     <button class="nav__toggle" type="button" aria-expanded="false" aria-controls="menu">Menu</button>
     <ul id="menu" class="nav__menu" data-state="closed">
-      <li><a href="/trilhas.html">Trilhas</a></li>
-      <li><a href="/guias.html" aria-current="page">Guias CADASTUR</a></li>
-      <li><a href="/expedicoes.html">Expedições</a></li>
-      <li><a href="/login.html" class="button button--primary">Entrar</a></li>
+      <li><a href="trilhas.html">Trilhas</a></li>
+      <li><a href="guias.html" aria-current="page">Guias CADASTUR</a></li>
+      <li><a href="expedicoes.html">Expedições</a></li>
+      <li><a href="login.html" class="button button--primary">Entrar</a></li>
     </ul>
   </nav>
 </header>
@@ -81,12 +82,12 @@
 </main>
 <footer class="site-footer">
   <nav aria-label="Rodapé">
-    <a href="/sobre.html">Sobre</a>
-    <a href="/contato.html">Contato</a>
-    <a href="/politica.html">Política e Termos</a>
+    <a href="sobre.html">Sobre</a>
+    <a href="contato.html">Contato</a>
+    <a href="politica.html">Política e Termos</a>
   </nav>
   <small>© Trekko</small>
 </footer>
-<script src="/assets/js/main.js" defer></script>
+<script src="assets/js/main.js" defer></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -2,6 +2,7 @@
 <html lang="pt-BR">
 <head>
   <meta charset="utf-8" />
+  <base href="/Trekko/" />
   <meta http-equiv="X-UA-Compatible" content="IE=edge" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>Trekko — Trilhas, Guias CADASTUR e Expedições</title>
@@ -9,8 +10,8 @@
   <link rel="canonical" href="https://www.trekko.com.br/" />
   <link rel="preconnect" href="https://cdn.trekko.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link rel="preload" href="/assets/css/main.css" as="style" />
-  <link rel="stylesheet" href="/assets/css/main.css" />
+  <link rel="preload" href="assets/css/main.css" as="style" />
+  <link rel="stylesheet" href="assets/css/main.css" />
   <meta property="og:title" content="Trekko — Trilhas, Guias CADASTUR e Expedições" />
   <meta property="og:description" content="A plataforma brasileira para trilhas certificadas, guias e expedições." />
   <meta property="og:url" content="https://www.trekko.com.br/" />
@@ -45,14 +46,14 @@
 <header class="site-header">
   <div class="alert-banner" role="status">Plataforma em beta. Dados oficiais CADASTUR e ICMBio atualizados diariamente.</div>
   <nav class="nav" aria-label="Principal">
-    <a class="nav__logo" href="/">Trekko</a>
+    <a class="nav__logo" href="./">Trekko</a>
     <button class="nav__toggle" type="button" aria-expanded="false" aria-controls="menu">Menu</button>
     <ul id="menu" class="nav__menu" data-state="closed">
-      <li><a href="/trilhas.html">Trilhas</a></li>
-      <li><a href="/guias.html">Guias CADASTUR</a></li>
-      <li><a href="/expedicoes.html">Expedições</a></li>
-      <li><a href="/sobre.html">Sobre</a></li>
-      <li><a href="/login.html" class="button button--primary">Entrar</a></li>
+      <li><a href="trilhas.html">Trilhas</a></li>
+      <li><a href="guias.html">Guias CADASTUR</a></li>
+      <li><a href="expedicoes.html">Expedições</a></li>
+      <li><a href="sobre.html">Sobre</a></li>
+      <li><a href="login.html" class="button button--primary">Entrar</a></li>
     </ul>
   </nav>
 </header>
@@ -64,7 +65,7 @@
         <p class="hero__subtitle">Busque por trilhas homologadas, guias certificados e expedições com disponibilidade real no Brasil inteiro.</p>
       </div>
     </div>
-    <form class="search-bar" id="searchForm" action="/trilhas.html" method="get" data-analytics="filter" data-category="home_search">
+    <form class="search-bar" id="searchForm" action="trilhas.html" method="get" data-analytics="filter" data-category="home_search">
       <div class="search-bar__group">
         <label for="q">Trilha, Parque, Cidade ou Estado</label>
         <input id="q" name="q" class="search-bar__field" type="search" placeholder="Ex.: Serra Fina, Itatiaia, MG" autocomplete="off" required minlength="2" />
@@ -80,7 +81,7 @@
         <h2 id="trail-highlights" class="section__title">Trilhas em destaque</h2>
         <p class="section__description">Confira as 10 trilhas mais buscadas pelos aventureiros nesta semana.</p>
       </div>
-      <a class="button button--ghost" href="/trilhas.html">Ver todas</a>
+      <a class="button button--ghost" href="trilhas.html">Ver todas</a>
     </div>
     <div class="cards" id="trailHighlights" data-state="loading" aria-live="polite" aria-busy="true"></div>
   </section>
@@ -91,7 +92,7 @@
         <h2 id="guides" class="section__title">Guias certificados (CADASTUR)</h2>
         <p class="section__description">Todos os guias são validados na base CADASTUR diariamente. Faça sua expedição com quem entende.</p>
       </div>
-      <a class="button button--ghost" href="/guias.html">Ver todos os guias</a>
+      <a class="button button--ghost" href="guias.html">Ver todos os guias</a>
     </div>
     <div class="cards" id="guideHighlights" data-state="loading" aria-live="polite" aria-busy="true"></div>
   </section>
@@ -110,7 +111,7 @@
         <h2 id="blog" class="section__title">Blog e conteúdo</h2>
         <p class="section__description">Artigos sobre segurança em trilhas, checklist de equipamentos e relatos de expedições.</p>
       </div>
-      <a class="button button--ghost" href="/blog.html">Ir para o blog</a>
+      <a class="button button--ghost" href="blog.html">Ir para o blog</a>
     </div>
     <div class="cards" data-state="ready">
       <article class="card">
@@ -118,7 +119,7 @@
           <h3 class="card__title">Checklist de equipamentos para travessias longas</h3>
           <p class="card__meta">Por Equipe Trekko</p>
           <p>Entenda os itens indispensáveis para trilhas acima de 20 km e como otimizar o peso da mochila.</p>
-          <a class="button button--ghost" href="/blog/checklist-equipamentos.html">Ler artigo</a>
+          <a class="button button--ghost" href="blog/checklist-equipamentos.html">Ler artigo</a>
         </div>
       </article>
       <article class="card">
@@ -126,7 +127,7 @@
           <h3 class="card__title">Como funciona a certificação CADASTUR</h3>
           <p class="card__meta">Por Ministério do Turismo</p>
           <p>Saiba como identificar um guia certificado e os benefícios para turistas e para o trade turístico.</p>
-          <a class="button button--ghost" href="/blog/cadastur.html">Ler artigo</a>
+          <a class="button button--ghost" href="blog/cadastur.html">Ler artigo</a>
         </div>
       </article>
     </div>
@@ -138,20 +139,20 @@
         <h2 id="cta-guia" class="section__title">É guia CADASTUR? Ative seu perfil</h2>
         <p class="section__description">Se você já está na base CADASTUR, basta ativar seu perfil Trekko para divulgar expedições e receber reservas.</p>
       </div>
-      <a class="button button--primary" href="/login.html?ativar=1" data-analytics="cta" data-category="activate-guide">Ativar guia</a>
+      <a class="button button--primary" href="login.html?ativar=1" data-analytics="cta" data-category="activate-guide">Ativar guia</a>
     </div>
   </section>
 </main>
 <footer class="site-footer">
   <nav aria-label="Rodapé">
-    <a href="/sobre.html">Sobre</a>
-    <a href="/contato.html">Contato</a>
-    <a href="/politica.html">Política e Termos</a>
-    <a href="/sitemap.xml">Sitemap</a>
+    <a href="sobre.html">Sobre</a>
+    <a href="contato.html">Contato</a>
+    <a href="politica.html">Política e Termos</a>
+    <a href="sitemap.xml">Sitemap</a>
   </nav>
   <small>© <span id="currentYear">2024</span> Trekko • Todos os direitos reservados</small>
 </footer>
 <script>document.getElementById('currentYear').textContent=new Date().getFullYear();</script>
-<script src="/assets/js/main.js" defer></script>
+<script src="assets/js/main.js" defer></script>
 </body>
 </html>

--- a/login.html
+++ b/login.html
@@ -2,24 +2,25 @@
 <html lang="pt-BR">
 <head>
   <meta charset="utf-8" />
+  <base href="/Trekko/" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>Entrar na Trekko</title>
   <meta name="description" content="Acesse sua conta Trekko para acompanhar trilhas, expedições e ativar seu perfil de guia." />
   <link rel="canonical" href="https://www.trekko.com.br/login.html" />
-  <link rel="preload" href="/assets/css/main.css" as="style" />
-  <link rel="stylesheet" href="/assets/css/main.css" />
+  <link rel="preload" href="assets/css/main.css" as="style" />
+  <link rel="stylesheet" href="assets/css/main.css" />
 </head>
 <body>
 <a class="skip-link" href="#principal">Pular para o conteúdo</a>
 <header class="site-header">
   <nav class="nav" aria-label="Principal">
-    <a class="nav__logo" href="/">Trekko</a>
+    <a class="nav__logo" href="./">Trekko</a>
     <button class="nav__toggle" type="button" aria-expanded="false" aria-controls="menu">Menu</button>
     <ul id="menu" class="nav__menu" data-state="closed">
-      <li><a href="/trilhas.html">Trilhas</a></li>
-      <li><a href="/guias.html">Guias CADASTUR</a></li>
-      <li><a href="/expedicoes.html">Expedições</a></li>
-      <li><a href="/signup.html" class="button button--ghost">Criar conta</a></li>
+      <li><a href="trilhas.html">Trilhas</a></li>
+      <li><a href="guias.html">Guias CADASTUR</a></li>
+      <li><a href="expedicoes.html">Expedições</a></li>
+      <li><a href="signup.html" class="button button--ghost">Criar conta</a></li>
     </ul>
   </nav>
 </header>
@@ -42,7 +43,7 @@
     </div>
     <div class="form__actions">
       <button class="button button--primary" type="submit">Entrar</button>
-      <a class="link" href="/signup.html">Criar conta</a>
+      <a class="link" href="signup.html">Criar conta</a>
     </div>
   </form>
 
@@ -72,12 +73,12 @@
 </main>
 <footer class="site-footer">
   <nav aria-label="Rodapé">
-    <a href="/sobre.html">Sobre</a>
-    <a href="/contato.html">Contato</a>
-    <a href="/politica.html">Política e Termos</a>
+    <a href="sobre.html">Sobre</a>
+    <a href="contato.html">Contato</a>
+    <a href="politica.html">Política e Termos</a>
   </nav>
   <small>© Trekko</small>
 </footer>
-<script src="/assets/js/main.js" defer></script>
+<script src="assets/js/main.js" defer></script>
 </body>
 </html>

--- a/politica.html
+++ b/politica.html
@@ -2,24 +2,25 @@
 <html lang="pt-BR">
 <head>
   <meta charset="utf-8" />
+  <base href="/Trekko/" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>Política de Privacidade e Termos — Trekko</title>
   <meta name="description" content="Conheça nossas políticas de privacidade, termos de uso e práticas de segurança." />
   <link rel="canonical" href="https://www.trekko.com.br/politica.html" />
-  <link rel="preload" href="/assets/css/main.css" as="style" />
-  <link rel="stylesheet" href="/assets/css/main.css" />
+  <link rel="preload" href="assets/css/main.css" as="style" />
+  <link rel="stylesheet" href="assets/css/main.css" />
 </head>
 <body>
 <a class="skip-link" href="#conteudo">Pular para o conteúdo</a>
 <header class="site-header">
   <nav class="nav" aria-label="Principal">
-    <a class="nav__logo" href="/">Trekko</a>
+    <a class="nav__logo" href="./">Trekko</a>
     <button class="nav__toggle" type="button" aria-expanded="false" aria-controls="menu">Menu</button>
     <ul id="menu" class="nav__menu" data-state="closed">
-      <li><a href="/trilhas.html">Trilhas</a></li>
-      <li><a href="/guias.html">Guias CADASTUR</a></li>
-      <li><a href="/expedicoes.html">Expedições</a></li>
-      <li><a href="/login.html" class="button button--ghost">Entrar</a></li>
+      <li><a href="trilhas.html">Trilhas</a></li>
+      <li><a href="guias.html">Guias CADASTUR</a></li>
+      <li><a href="expedicoes.html">Expedições</a></li>
+      <li><a href="login.html" class="button button--ghost">Entrar</a></li>
     </ul>
   </nav>
 </header>
@@ -57,12 +58,12 @@
 </main>
 <footer class="site-footer">
   <nav aria-label="Rodapé">
-    <a href="/sobre.html">Sobre</a>
-    <a href="/contato.html">Contato</a>
-    <a href="/politica.html" aria-current="page">Política e Termos</a>
+    <a href="sobre.html">Sobre</a>
+    <a href="contato.html">Contato</a>
+    <a href="politica.html" aria-current="page">Política e Termos</a>
   </nav>
   <small>© Trekko</small>
 </footer>
-<script src="/assets/js/main.js" defer></script>
+<script src="assets/js/main.js" defer></script>
 </body>
 </html>

--- a/signup.html
+++ b/signup.html
@@ -2,24 +2,25 @@
 <html lang="pt-BR">
 <head>
   <meta charset="utf-8" />
+  <base href="/Trekko/" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>Criar conta Trekko</title>
   <meta name="description" content="Cadastre-se na Trekko para salvar trilhas, comentar e ativar seu perfil de guia CADASTUR." />
   <link rel="canonical" href="https://www.trekko.com.br/signup.html" />
-  <link rel="preload" href="/assets/css/main.css" as="style" />
-  <link rel="stylesheet" href="/assets/css/main.css" />
+  <link rel="preload" href="assets/css/main.css" as="style" />
+  <link rel="stylesheet" href="assets/css/main.css" />
 </head>
 <body>
 <a class="skip-link" href="#principal">Pular para o conteúdo</a>
 <header class="site-header">
   <nav class="nav" aria-label="Principal">
-    <a class="nav__logo" href="/">Trekko</a>
+    <a class="nav__logo" href="./">Trekko</a>
     <button class="nav__toggle" type="button" aria-expanded="false" aria-controls="menu">Menu</button>
     <ul id="menu" class="nav__menu" data-state="closed">
-      <li><a href="/trilhas.html">Trilhas</a></li>
-      <li><a href="/guias.html">Guias CADASTUR</a></li>
-      <li><a href="/expedicoes.html">Expedições</a></li>
-      <li><a href="/login.html" class="button button--ghost">Entrar</a></li>
+      <li><a href="trilhas.html">Trilhas</a></li>
+      <li><a href="guias.html">Guias CADASTUR</a></li>
+      <li><a href="expedicoes.html">Expedições</a></li>
+      <li><a href="login.html" class="button button--ghost">Entrar</a></li>
     </ul>
   </nav>
 </header>
@@ -51,15 +52,15 @@
     <label class="form__group"><input type="checkbox" name="aceite" value="true" required /> Concordo com os Termos e Política de Privacidade</label>
     <div class="form__actions">
       <button class="button button--primary" type="submit">Criar conta</button>
-      <a class="link" href="/login.html">Já tenho conta</a>
+      <a class="link" href="login.html">Já tenho conta</a>
     </div>
   </form>
 </main>
 <footer class="site-footer">
   <nav aria-label="Rodapé">
-    <a href="/sobre.html">Sobre</a>
-    <a href="/contato.html">Contato</a>
-    <a href="/politica.html">Política e Termos</a>
+    <a href="sobre.html">Sobre</a>
+    <a href="contato.html">Contato</a>
+    <a href="politica.html">Política e Termos</a>
   </nav>
   <small>© Trekko</small>
 </footer>
@@ -73,6 +74,6 @@
     }
   });
 </script>
-<script src="/assets/js/main.js" defer></script>
+<script src="assets/js/main.js" defer></script>
 </body>
 </html>

--- a/sobre.html
+++ b/sobre.html
@@ -2,24 +2,25 @@
 <html lang="pt-BR">
 <head>
   <meta charset="utf-8" />
+  <base href="/Trekko/" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>Sobre a Trekko</title>
   <meta name="description" content="Conheça a história da Trekko, nossa missão e compromissos com trilheiros e guias certificados." />
   <link rel="canonical" href="https://www.trekko.com.br/sobre.html" />
-  <link rel="preload" href="/assets/css/main.css" as="style" />
-  <link rel="stylesheet" href="/assets/css/main.css" />
+  <link rel="preload" href="assets/css/main.css" as="style" />
+  <link rel="stylesheet" href="assets/css/main.css" />
 </head>
 <body>
 <a class="skip-link" href="#conteudo">Pular para o conteúdo</a>
 <header class="site-header">
   <nav class="nav" aria-label="Principal">
-    <a class="nav__logo" href="/">Trekko</a>
+    <a class="nav__logo" href="./">Trekko</a>
     <button class="nav__toggle" type="button" aria-expanded="false" aria-controls="menu">Menu</button>
     <ul id="menu" class="nav__menu" data-state="closed">
-      <li><a href="/trilhas.html">Trilhas</a></li>
-      <li><a href="/guias.html">Guias CADASTUR</a></li>
-      <li><a href="/expedicoes.html">Expedições</a></li>
-      <li><a href="/login.html" class="button button--ghost">Entrar</a></li>
+      <li><a href="trilhas.html">Trilhas</a></li>
+      <li><a href="guias.html">Guias CADASTUR</a></li>
+      <li><a href="expedicoes.html">Expedições</a></li>
+      <li><a href="login.html" class="button button--ghost">Entrar</a></li>
     </ul>
   </nav>
 </header>
@@ -52,12 +53,12 @@
 </main>
 <footer class="site-footer">
   <nav aria-label="Rodapé">
-    <a href="/sobre.html" aria-current="page">Sobre</a>
-    <a href="/contato.html">Contato</a>
-    <a href="/politica.html">Política e Termos</a>
+    <a href="sobre.html" aria-current="page">Sobre</a>
+    <a href="contato.html">Contato</a>
+    <a href="politica.html">Política e Termos</a>
   </nav>
   <small>© Trekko</small>
 </footer>
-<script src="/assets/js/main.js" defer></script>
+<script src="assets/js/main.js" defer></script>
 </body>
 </html>

--- a/trilha.html
+++ b/trilha.html
@@ -2,12 +2,13 @@
 <html lang="pt-BR">
 <head>
   <meta charset="utf-8" />
+  <base href="/Trekko/" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>Detalhe da trilha — Trekko</title>
   <meta name="description" content="Informações detalhadas sobre trilhas oficiais: distância, nível, infraestrutura, custos e expedições futuras." />
   <link rel="canonical" href="https://www.trekko.com.br/trilha.html" />
-  <link rel="preload" href="/assets/css/main.css" as="style" />
-  <link rel="stylesheet" href="/assets/css/main.css" />
+  <link rel="preload" href="assets/css/main.css" as="style" />
+  <link rel="stylesheet" href="assets/css/main.css" />
   <meta property="og:title" content="Detalhe da trilha — Trekko" />
   <meta property="og:type" content="article" />
   <meta property="og:description" content="Veja dados completos da trilha, logística, comentários e expedições." />
@@ -19,13 +20,13 @@
 <a class="skip-link" href="#conteudo">Pular para o conteúdo</a>
 <header class="site-header">
   <nav class="nav" aria-label="Principal">
-    <a class="nav__logo" href="/">Trekko</a>
+    <a class="nav__logo" href="./">Trekko</a>
     <button class="nav__toggle" type="button" aria-expanded="false" aria-controls="menu">Menu</button>
     <ul id="menu" class="nav__menu" data-state="closed">
-      <li><a href="/trilhas.html">Trilhas</a></li>
-      <li><a href="/guias.html">Guias CADASTUR</a></li>
-      <li><a href="/expedicoes.html">Expedições</a></li>
-      <li><a href="/login.html" class="button button--primary">Entrar</a></li>
+      <li><a href="trilhas.html">Trilhas</a></li>
+      <li><a href="guias.html">Guias CADASTUR</a></li>
+      <li><a href="expedicoes.html">Expedições</a></li>
+      <li><a href="login.html" class="button button--primary">Entrar</a></li>
     </ul>
   </nav>
 </header>
@@ -71,7 +72,7 @@
   <section class="section" aria-labelledby="expedicoes">
     <div class="section__header">
       <h2 id="expedicoes" class="section__title">Próximas expedições</h2>
-      <a class="button button--ghost" href="/expedicoes.html" data-analytics="cta" data-category="trail">Ver todas as expedições</a>
+      <a class="button button--ghost" href="expedicoes.html" data-analytics="cta" data-category="trail">Ver todas as expedições</a>
     </div>
     <div id="trailExpeditions" class="grid" data-state="loading" aria-live="polite"></div>
   </section>
@@ -98,9 +99,9 @@
 </main>
 <footer class="site-footer">
   <nav aria-label="Rodapé">
-    <a href="/sobre.html">Sobre</a>
-    <a href="/contato.html">Contato</a>
-    <a href="/politica.html">Política e Termos</a>
+    <a href="sobre.html">Sobre</a>
+    <a href="contato.html">Contato</a>
+    <a href="politica.html">Política e Termos</a>
   </nav>
   <small>© Trekko</small>
 </footer>
@@ -114,6 +115,6 @@
     }
   })();
 </script>
-<script src="/assets/js/main.js" defer></script>
+<script src="assets/js/main.js" defer></script>
 </body>
 </html>

--- a/trilhas.html
+++ b/trilhas.html
@@ -2,13 +2,14 @@
 <html lang="pt-BR">
 <head>
   <meta charset="utf-8" />
+  <base href="/Trekko/" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>Trilhas reais pelo Brasil — Trekko</title>
   <meta name="description" content="Busque trilhas homologadas por parque, dificuldade, distância, infraestrutura e planeje sua próxima expedição." />
   <link rel="canonical" href="https://www.trekko.com.br/trilhas.html" />
   <link rel="preconnect" href="https://cdn.trekko.com" />
-  <link rel="preload" href="/assets/css/main.css" as="style" />
-  <link rel="stylesheet" href="/assets/css/main.css" />
+  <link rel="preload" href="assets/css/main.css" as="style" />
+  <link rel="stylesheet" href="assets/css/main.css" />
   <meta property="og:title" content="Trilhas reais pelo Brasil — Trekko" />
   <meta property="og:description" content="Filtre trilhas por distância, dificuldade e infraestrutura e encontre informações confiáveis." />
   <meta property="og:type" content="website" />
@@ -23,13 +24,13 @@
 <a class="skip-link" href="#content">Pular para o conteúdo</a>
 <header class="site-header">
   <nav class="nav" aria-label="Principal">
-    <a class="nav__logo" href="/">Trekko</a>
+    <a class="nav__logo" href="./">Trekko</a>
     <button class="nav__toggle" type="button" aria-expanded="false" aria-controls="menu">Menu</button>
     <ul id="menu" class="nav__menu" data-state="closed">
-      <li><a href="/trilhas.html" aria-current="page">Trilhas</a></li>
-      <li><a href="/guias.html">Guias CADASTUR</a></li>
-      <li><a href="/expedicoes.html">Expedições</a></li>
-      <li><a href="/login.html" class="button button--primary">Entrar</a></li>
+      <li><a href="trilhas.html" aria-current="page">Trilhas</a></li>
+      <li><a href="guias.html">Guias CADASTUR</a></li>
+      <li><a href="expedicoes.html">Expedições</a></li>
+      <li><a href="login.html" class="button button--primary">Entrar</a></li>
     </ul>
   </nav>
 </header>
@@ -106,12 +107,12 @@
 </main>
 <footer class="site-footer">
   <nav aria-label="Rodapé">
-    <a href="/sobre.html">Sobre</a>
-    <a href="/contato.html">Contato</a>
-    <a href="/politica.html">Política e Termos</a>
+    <a href="sobre.html">Sobre</a>
+    <a href="contato.html">Contato</a>
+    <a href="politica.html">Política e Termos</a>
   </nav>
   <small>© Trekko</small>
 </footer>
-<script src="/assets/js/main.js" defer></script>
+<script src="assets/js/main.js" defer></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add a base href across Trekko HTML pages and switch internal links and assets to relative URLs
- make front-end data fetching aware of the base path and align highlight/search endpoints with production APIs

## Testing
- not run (static site changes only)

------
https://chatgpt.com/codex/tasks/task_e_68e591d570a08324bb740960f151e717